### PR TITLE
Add config files back to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 
 # Azure Functions localsettings file
 local.settings.json
-appsettings.json
-appsettings.Development.json
 
 # User-specific files
 *.suo

--- a/solution/WebApplication/WebApplication.Tests/appsettings.json
+++ b/solution/WebApplication/WebApplication.Tests/appsettings.json
@@ -1,0 +1,43 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AZURE_TENANT_ID": "",
+    "AZURE_CLIENT_ID": "",
+    "AZURE_CLIENT_SECRET": "",
+    "UseMSI": false,
+    "AdsGoFastTaskMetaDataDatabaseServer": "",
+    "AdsGoFastTaskMetaDataDatabaseName": "",
+    "AppInsightsWorkspaceId": "",
+    "AdGroups": [
+    ],
+    "AllowedHosts": "*",
+    "SecurityModelOptions": {
+        "SecurityRoles": [
+            {
+                "SecurityGroupId": "ReaderSecurityId",
+                "Name": "Reader",
+                "AllowActions": [
+                    "ControllerA.Create",
+                    "ControllerB.Create",
+                    "ControllerA.Delete",
+                    "ControllerB.Details"
+                ]
+            }
+        ],
+        "GlobalAllowActions": [
+            "ControllerA.List",
+            "ControllerB.List",
+            "ControllerB.Details"
+        ],
+        "GlobalDenyActions": [
+            "ControllerA.Delete",
+            "ControllerB"
+        ]
+    }
+
+}

--- a/solution/WebApplication/WebApplication/appSettings-configuresecrets.ps1
+++ b/solution/WebApplication/WebApplication/appSettings-configuresecrets.ps1
@@ -1,0 +1,30 @@
+﻿#todo: this script may need to reach into both functions app and webapp in future
+[CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='High')]
+param (
+)
+
+$errorActionPreference = "Stop";
+if (-not $PSBoundParameters.ContainsKey('Confirm')) {
+    $ConfirmPreference = $PSCmdlet.SessionState.PSVariable.GetValue('ConfirmPreference')
+}
+
+$keys = @("AZURE_CLIENT_SECRET")
+
+pushd $PSScriptRoot
+try {
+	dotnet user-secrets init
+
+	foreach ($k in $keys) {
+		if($psCmdLet.ShouldProcess("$k",  "Update secret"))                                                              
+        {
+            Write-host "Provide new value:" 
+            #note - we dont' read as a masked value as dotnet-secret will spit out the plaintext anyway
+            $secret = read-host
+            # dotnet user-secrets set "Movies:ServiceApiKey" "12345" --project "C:\apps\WebApp1\src\WebApp1"
+            dotnet user-secrets set $k $secret
+        }   
+	}
+}
+finally {
+	popd
+}

--- a/solution/WebApplication/WebApplication/appsettings.Development.json
+++ b/solution/WebApplication/WebApplication/appsettings.Development.json
@@ -1,0 +1,26 @@
+{
+    "AZURE_TENANT_ID": "##GUID_HERE##",
+    "AZURE_CLIENT_ID": "##GUID_HERE##",
+    "AZURE_CLIENT_SECRET": "DO_NOT_SET_THIS_USE_DOTNET_SECRET",
+    "AppInsightsWorkspaceId": "####################",
+    "AdsGoFastTaskMetaDataDatabaseName": "databasename",
+    "AdsGoFastTaskMetaDataDatabaseServer": "databaseserver.database.windows.net",
+    "AzureAd": {
+        "Instance": "https://login.microsoftonline.com/",
+        "Domain": "contoso.com",
+        "TenantId": "",
+        "ClientId": "",
+        "CallbackPath": "/signin-oidc",
+        "SignedOutCallbackPath ": "/signout-callback-oidc"
+    },
+    "SecurityModelOptions": {
+        "SecurityRoles": [
+            {
+                "SecurityGroupId": "###GUID_HERE###",
+                "Name": "Administrators",
+                "AllowActions": [
+                ]
+            }
+        ]
+    }
+}

--- a/solution/WebApplication/WebApplication/appsettings.json
+++ b/solution/WebApplication/WebApplication/appsettings.json
@@ -1,0 +1,72 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AZURE_TENANT_ID": "",
+    "AZURE_CLIENT_ID": "",
+    "AZURE_CLIENT_SECRET": "",
+    "UseMSI": false,
+    "AdsGoFastTaskMetaDataDatabaseName": "",
+    "AdsGoFastTaskMetaDataDatabaseServer": "",
+    "AppInsightsWorkspaceId": "",
+    "AllowedHosts": "*",
+    "AzureAd": {
+        "Instance": "https://login.microsoftonline.com/",
+        "Domain": "",
+        "TenantId": "",
+        "ClientId": "",
+        "CallbackPath": "/signin-oidc",
+        "SignedOutCallbackPath ": "/signout-callback-oidc"
+    },
+    "SecurityModelOptions": {
+        "SecurityRoles": [],
+        "GlobalAllowActions": [
+            "ADFActivityErrors",
+            "ADFPipelineStats",
+            "AFExecutionSummary",
+            "AFLogMonitor",
+            "Dashboard",
+            "DataFactory",
+            "FrameworkTaskRunner",
+            "FrameworkTaskRunnerDapper",
+            "ReportsAndStatistics",
+            "ScheduleInstance",
+            "ScheduleMaster",
+            "SourceAndTargetSystems",
+            "SourceAndTargetSystemsJsonSchema",
+            "SubjectArea",
+            "TaskGroup",
+            "TaskGroupDependency",
+            "TaskInstance",
+            "TaskInstanceExecution",
+            "TaskMaster",
+            "TaskMasterWaterMark",
+            "TaskType",
+            "TaskTypeMapping",
+            "Wizards"
+
+        ],
+        "GlobalDenyActions": [
+            "Customisations.Delete",
+            "DataFactory.Delete",
+            "FrameworkTaskRunner.Delete",
+            "FrameworkTaskRunnerDapper.Delete",
+            "ScheduleInstance.Delete",
+            "ScheduleMaster.Delete",
+            "SourceAndTargetSystems.Delete",
+            "SourceAndTargetSystemsJsonSchema.Delete",
+            "TaskGroup.Delete",
+            "TaskGroupDependency.Delete",
+            "TaskGroupDependency.DeletePlus",
+            "TaskInstance.Delete",
+            "TaskMaster.Delete",
+            "TaskMasterWaterMark.Delete",
+            "TaskType.Delete",
+            "TaskTypeMapping.Delete"
+        ]
+    }
+}


### PR DESCRIPTION
This change puts the skeleton config files back into source control so that defaults can be managed more easily

- Allows tests to be run
- Gives skeleton sample to users without copying out of config on every single dev & build machine
- manages secret variables using dotnet secret
- Allows deployed builds created on CI/CD pipeline to access configuration stored in source control


Happy to discuss leaving out appsettings.Development.json if it's going to cause problems