### PR TITLE
Specify Deployment's parent folder as the container workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd environments/Node/
 npm install 
 node server.js 
 ```
->- [ ] Next Open an Internet Browser and navigate to http://localhost:8080/EditSettings.html. You  should see a screen that looks like the picture belo. For a vanilla deployment you only need to fill out the section titled "Primary Resource Group Settings". Fill this out now with your Azure Environment Specifics and, once done, click on the red button at the top of the form labelled "Click here to update the environment file with form changes". 
+>- [ ] Next Open an Internet Browser and navigate to http://localhost:8080/EditSettings.html. You  should see a screen that looks like the picture below. For a vanilla deployment you only need to fill out the section titled "Primary Resource Group Settings". Fill this out now with your Azure Environment Specifics and, once done, click on the red button at the top of the form labelled "Click here to update the environment file with form changes". 
 
 ![Form](./documentation/images/DeploymentForm.png)
 
@@ -103,7 +103,7 @@ The deployment uses a concept of **Developing inside a Container** to containeri
 
 ## Cost Estimator
 
-Comming Soon.
+Coming Soon.
 
 ---
 

--- a/solution/Deployment/.devcontainer/devcontainer.json
+++ b/solution/Deployment/.devcontainer/devcontainer.json
@@ -10,6 +10,12 @@
 	  //"terminal.integrated.cwd": "/home/vscode"
 	},
 	
+	// Instead of mounting the local workspace folder (Deployment) by default, 
+	// this should mount its parent folder (per "..") into the default /workspace folder 
+	// of the container.  This assumes that the Deployment folder was opened in vscode
+	"workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspace,type=bind",
+	"workspaceFolder": "/workspace",
+
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-vscode.azurecli"


### PR DESCRIPTION
By default, when opening the `Deployment` folder into VS Code, it mounts it as the `/workspace` for the container.

This change will modify the default to its parent folder, `solution` so that other scripts are accessible by the container.

Also, this includes minor typo fixes.