### PR TITLE
Assign AAD app registration owners

### DIFF
--- a/solution/DeploymentV2/terraform/app_service.tf
+++ b/solution/DeploymentV2/terraform/app_service.tf
@@ -2,7 +2,7 @@
 resource "azuread_application" "web" {
   count           = var.deploy_azure_ad_web_app_registration ? 1 : 0
   display_name    = local.aad_webapp_name
-  identifier_uris = [local.webapp_identifier_uri]
+  owners           = [data.azurerm_client_config.current.object_id]
   web {
     homepage_url  = local.webapp_url
     redirect_uris = ["${local.webapp_url}/signin-oidc"]

--- a/solution/DeploymentV2/terraform/function_app.tf
+++ b/solution/DeploymentV2/terraform/function_app.tf
@@ -1,7 +1,7 @@
 resource "azuread_application" "function_app" {
   count           = var.deploy_azure_ad_function_app_registration ? 1 : 0
+  owners           = [data.azurerm_client_config.current.object_id]
   display_name    = local.aad_functionapp_name
-  identifier_uris = [local.functionapp_identifier_uri]
   web {
     homepage_url = local.functionapp_url
     implicit_grant {


### PR DESCRIPTION
Fixes an issue where some users are unable to add a service principal after creating the app registration.