### PR TITLE
Updated TF and deployment to use the pattern based ADF pipelines

### DIFF
--- a/solution/DeploymentV2/terraform/app_insights.tf
+++ b/solution/DeploymentV2/terraform/app_insights.tf
@@ -18,3 +18,10 @@ resource "azurerm_role_assignment" "app_insights_web_app" {
   role_definition_name = "Contributor"
   principal_id         = azurerm_app_service.web[0].identity[0].principal_id
 }
+
+resource "azurerm_role_assignment" "app_insights_function_app" {
+  count                = (var.deploy_app_insights ? 1 : 0)
+  scope                = azurerm_application_insights.app_insights[0].id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_function_app.function_app.identity[0].principal_id
+}

--- a/solution/DeploymentV2/terraform/app_service.tf
+++ b/solution/DeploymentV2/terraform/app_service.tf
@@ -2,14 +2,15 @@
 resource "random_uuid" "app_reg_role_id" {}
 
 resource "azuread_application" "web_reg" {
-  count        = var.deploy_azure_ad_web_app_registration ? 1 : 0
-  display_name = local.aad_webapp_name
-  owners       = [data.azurerm_client_config.current.object_id]
+  count           = var.deploy_azure_ad_web_app_registration ? 1 : 0
+  display_name    = local.aad_webapp_name
+  owners           = [data.azurerm_client_config.current.object_id]
   web {
     homepage_url  = local.webapp_url
-    redirect_uris = ["${local.webapp_url}/signin-oidc"]
+    redirect_uris = ["${local.webapp_url}/signin-oidc", "https://localhost:44385/signin-oidc"]
     implicit_grant {
       access_token_issuance_enabled = false
+      id_token_issuance_enabled     = true
     }
   }
   app_role {
@@ -33,6 +34,7 @@ resource "azuread_application" "web_reg" {
 resource "azuread_service_principal" "web_sp" {
   count          = var.deploy_azure_ad_web_app_registration ? 1 : 0
   application_id = azuread_application.web_reg[0].application_id
+  owners         = [data.azurerm_client_config.current.object_id]
 }
 
 resource "azurerm_app_service" "web" {
@@ -51,7 +53,7 @@ resource "azurerm_app_service" "web" {
     ApplicationOptions__AdsGoFastTaskMetaDataDatabaseServer = "${azurerm_mssql_server.sqlserver[0].name}.database.windows.net"
     ApplicationOptions__AdsGoFastTaskMetaDataDatabaseName   = azurerm_mssql_database.web_db[0].name
 
-    ApplicationOptions__AppInsightsWorkspaceId  = azurerm_log_analytics_workspace.log_analytics_workspace.id
+    ApplicationOptions__AppInsightsWorkspaceId  = azurerm_application_insights.app_insights[0].app_id
     ApplicationOptions__LogAnalyticsWorkspaceId = azurerm_log_analytics_workspace.log_analytics_workspace.id
 
     AzureAdAuth__Domain   = var.domain

--- a/solution/DeploymentV2/terraform/app_service.tf
+++ b/solution/DeploymentV2/terraform/app_service.tf
@@ -2,9 +2,9 @@
 resource "random_uuid" "app_reg_role_id" {}
 
 resource "azuread_application" "web_reg" {
-  count           = var.deploy_azure_ad_web_app_registration ? 1 : 0
-  display_name    = local.aad_webapp_name
-  owners           = [data.azurerm_client_config.current.object_id]
+  count        = var.deploy_azure_ad_web_app_registration ? 1 : 0
+  display_name = local.aad_webapp_name
+  owners       = [data.azurerm_client_config.current.object_id]
   web {
     homepage_url  = local.webapp_url
     redirect_uris = ["${local.webapp_url}/signin-oidc", "https://localhost:44385/signin-oidc"]

--- a/solution/DeploymentV2/terraform/data_factory.tf
+++ b/solution/DeploymentV2/terraform/data_factory.tf
@@ -23,13 +23,13 @@ resource "azurerm_role_assignment" "datafactory_function_app" {
 
 # // Diagnostic logs--------------------------------------------------------------------------
 resource "azurerm_monitor_diagnostic_setting" "data_factory_diagnostic_logs" {
-  name                           = "diagnosticlogs"
+  name = "diagnosticlogs"
   # ignore_changes is here given the bug  https://github.com/terraform-providers/terraform-provider-azurerm/issues/10388
   lifecycle {
     ignore_changes = [log, metric]
   }
-  target_resource_id         = azurerm_data_factory.data_factory.id
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.log_analytics_workspace.id
+  target_resource_id             = azurerm_data_factory.data_factory.id
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.log_analytics_workspace.id
   log_analytics_destination_type = "Dedicated"
 
   log {

--- a/solution/DeploymentV2/terraform/data_factory.tf
+++ b/solution/DeploymentV2/terraform/data_factory.tf
@@ -23,13 +23,13 @@ resource "azurerm_role_assignment" "datafactory_function_app" {
 
 # // Diagnostic logs--------------------------------------------------------------------------
 resource "azurerm_monitor_diagnostic_setting" "data_factory_diagnostic_logs" {
-  name = "diagnosticlogs"
+  name                           = "diagnosticlogs"
   # ignore_changes is here given the bug  https://github.com/terraform-providers/terraform-provider-azurerm/issues/10388
   lifecycle {
     ignore_changes = [log, metric]
   }
-  target_resource_id             = azurerm_data_factory.data_factory.id
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.log_analytics_workspace.id
+  target_resource_id         = azurerm_data_factory.data_factory.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.log_analytics_workspace.id
   log_analytics_destination_type = "Dedicated"
 
   log {

--- a/solution/DeploymentV2/terraform/data_factory_datasets.tf
+++ b/solution/DeploymentV2/terraform/data_factory_datasets.tf
@@ -2,6 +2,7 @@ module "data_factory_datasets" {
   for_each = {
     for ir in local.integration_runtimes :
     ir.short_name => ir
+    if (ir.is_azure == true || var.is_onprem_datafactory_ir_registered == true)
   }
   source                         = "./modules/data_factory_datasets"
   resource_group_name            = var.resource_group_name

--- a/solution/DeploymentV2/terraform/data_factory_linked_services.tf
+++ b/solution/DeploymentV2/terraform/data_factory_linked_services.tf
@@ -35,7 +35,11 @@ resource "azurerm_data_factory_linked_service_azure_function" "function_app" {
 # Generic Linked Services (1 per Integration Runtime)
 #------------------------------------------------------------------------------------------------------
 resource "azurerm_data_factory_linked_custom_service" "generic_kv" {
-  for_each             = { for ir in local.integration_runtimes : ir.short_name => ir }
+  for_each             = { 
+    for ir in local.integration_runtimes : 
+    ir.short_name => ir 
+    if (ir.is_azure == true || var.is_onprem_datafactory_ir_registered == true)
+    }
   name                 = "${local.linkedservice_generic_kv_prefix}${each.value.short_name}"
   data_factory_id      = azurerm_data_factory.data_factory.id
   type                 = "AzureKeyVault"
@@ -88,7 +92,7 @@ resource "azurerm_data_factory_linked_custom_service" "blob" {
   for_each = {
     for ir in local.integration_runtimes :
     ir.short_name => ir
-    if ir.is_azure == true
+    if (ir.is_azure == true || var.is_onprem_datafactory_ir_registered == true)
   }
   name                 = "${local.linkedservice_generic_blob_prefix}${each.value.short_name}"
   data_factory_id      = azurerm_data_factory.data_factory.id
@@ -143,6 +147,7 @@ resource "azurerm_data_factory_linked_custom_service" "mssqldatabase" {
   for_each = {
     for ir in local.integration_runtimes :
     ir.short_name => ir
+    if (var.is_onprem_datafactory_ir_registered == true)
   }
   name            = "${local.linkedservice_generic_mssql_prefix}${each.value.short_name}"
   data_factory_id = azurerm_data_factory.data_factory.id
@@ -189,7 +194,11 @@ JSON
 
 
 resource "azurerm_data_factory_linked_custom_service" "file" {
-  for_each        = { for ir in local.integration_runtimes : ir.short_name => ir }
+  for_each        = { 
+    for ir in local.integration_runtimes : 
+    ir.short_name => ir 
+    if (ir.is_azure == true || var.is_onprem_datafactory_ir_registered == true)
+  }
   name            = "${local.linkedservice_generic_file_prefix}${each.value.short_name}"
   data_factory_id = azurerm_data_factory.data_factory.id
   type            = "FileServer"

--- a/solution/DeploymentV2/terraform/data_factory_pipelines.tf
+++ b/solution/DeploymentV2/terraform/data_factory_pipelines.tf
@@ -35,7 +35,7 @@ module "data_factory_pipelines_selfhosted" {
   for_each = {
     for ir in local.integration_runtimes :
     ir.short_name => ir
-    if ir.is_azure == false
+    if (ir.is_azure == false && var.is_onprem_datafactory_ir_registered == true)
   }
   resource_group_name            = var.resource_group_name
   data_factory_name              = local.data_factory_name

--- a/solution/DeploymentV2/terraform/database.tf
+++ b/solution/DeploymentV2/terraform/database.tf
@@ -1,8 +1,15 @@
 
 
 resource "random_password" "database" {
-  length  = 32
-  special = false
+  length      = 32
+  min_numeric = 1
+  min_upper   = 1
+  min_lower   = 1
+  min_special = 1
+  special     = true
+  lower       = true
+  number      = true
+  upper       = true
 }
 
 # Database Server

--- a/solution/DeploymentV2/terraform/database.tf
+++ b/solution/DeploymentV2/terraform/database.tf
@@ -1,15 +1,8 @@
 
 
 resource "random_password" "database" {
-  length      = 32
-  min_numeric = 1
-  min_upper   = 1
-  min_lower   = 1
-  min_special = 1
-  special     = true
-  lower       = true
-  number      = true
-  upper       = true
+  length  = 32
+  special = false
 }
 
 # Database Server
@@ -21,7 +14,7 @@ resource "azurerm_mssql_server" "sqlserver" {
   version                       = "12.0"
   administrator_login           = var.sql_admin_username
   administrator_login_password  = random_password.database.result
-  public_network_access_enabled = false
+  public_network_access_enabled = var.is_vnet_isolated == false || var.delay_private_access
   minimum_tls_version           = "1.2"
 
   azuread_administrator {

--- a/solution/DeploymentV2/terraform/key_vault.tf
+++ b/solution/DeploymentV2/terraform/key_vault.tf
@@ -167,6 +167,6 @@ resource "azurerm_key_vault_secret" "purview_ir_sp_password" {
   key_vault_id = azurerm_key_vault.app_vault.id
   depends_on = [
     azurerm_key_vault_access_policy.cicd_access
-  ]
+  ]  
 }
 

--- a/solution/DeploymentV2/terraform/key_vault.tf
+++ b/solution/DeploymentV2/terraform/key_vault.tf
@@ -167,6 +167,6 @@ resource "azurerm_key_vault_secret" "purview_ir_sp_password" {
   key_vault_id = azurerm_key_vault.app_vault.id
   depends_on = [
     azurerm_key_vault_access_policy.cicd_access
-  ]  
+  ]
 }
 

--- a/solution/DeploymentV2/terraform/locals.tf
+++ b/solution/DeploymentV2/terraform/locals.tf
@@ -31,10 +31,10 @@ locals {
   purview_resource_group_name  = "managed-${module.naming.resource_group.name_unique}-purview"
   purview_ir_app_reg_name      = (var.purview_ir_app_reg_name != "" ? var.purview_ir_app_reg_name : "ADS GoFast Purview Integration Runtime (${var.environment_tag})")
   jumphost_vm_name             = module.naming.virtual_machine.name
-  synapse_data_lake_name       = (var.synapse_data_lake_name != ""? var.synapse_data_lake_name : module.naming.data_lake_store.name_unique)
-  synapse_workspace_name       = (var.synapse_workspace_name != ""? var.synapse_workspace_name : "${var.prefix}${var.environment_tag}synw${var.app_name}")
-  synapse_dwpool_name          = (var.synapse_dwpool_name != ""? var.synapse_dwpool_name : "${var.prefix}${var.environment_tag}syndp${var.app_name}")
-  synapse_sppool_name          = (var.synapse_sppool_name != ""? var.synapse_sppool_name : "${var.prefix}${var.environment_tag}synsp${var.app_name}")
+  synapse_data_lake_name       = (var.synapse_data_lake_name != "" ? var.synapse_data_lake_name : module.naming.data_lake_store.name_unique)
+  synapse_workspace_name       = (var.synapse_workspace_name != "" ? var.synapse_workspace_name : "${var.prefix}${var.environment_tag}synw${var.app_name}")
+  synapse_dwpool_name          = (var.synapse_dwpool_name != "" ? var.synapse_dwpool_name : "${var.prefix}${var.environment_tag}syndp${var.app_name}")
+  synapse_sppool_name          = (var.synapse_sppool_name != "" ? var.synapse_sppool_name : "${var.prefix}${var.environment_tag}synsp${var.app_name}")
   synapse_resource_group_name  = "managed-${module.naming.resource_group.name_unique}-synapse"
 
   tags = {

--- a/solution/DeploymentV2/terraform/locals.tf
+++ b/solution/DeploymentV2/terraform/locals.tf
@@ -31,10 +31,10 @@ locals {
   purview_resource_group_name  = "managed-${module.naming.resource_group.name_unique}-purview"
   purview_ir_app_reg_name      = (var.purview_ir_app_reg_name != "" ? var.purview_ir_app_reg_name : "ADS GoFast Purview Integration Runtime (${var.environment_tag})")
   jumphost_vm_name             = module.naming.virtual_machine.name
-  synapse_data_lake_name       = (var.synapse_data_lake_name != "" ? var.synapse_data_lake_name : module.naming.data_lake_store.name_unique)
-  synapse_workspace_name       = (var.synapse_workspace_name != "" ? var.synapse_workspace_name : "${var.prefix}${var.environment_tag}synw${var.app_name}")
-  synapse_dwpool_name          = (var.synapse_dwpool_name != "" ? var.synapse_dwpool_name : "${var.prefix}${var.environment_tag}syndp${var.app_name}")
-  synapse_sppool_name          = (var.synapse_sppool_name != "" ? var.synapse_sppool_name : "${var.prefix}${var.environment_tag}synsp${var.app_name}")
+  synapse_data_lake_name       = (var.synapse_data_lake_name != ""? var.synapse_data_lake_name : module.naming.data_lake_store.name_unique)
+  synapse_workspace_name       = (var.synapse_workspace_name != ""? var.synapse_workspace_name : "${var.prefix}${var.environment_tag}synw${var.app_name}")
+  synapse_dwpool_name          = (var.synapse_dwpool_name != ""? var.synapse_dwpool_name : "${var.prefix}${var.environment_tag}syndp${var.app_name}")
+  synapse_sppool_name          = (var.synapse_sppool_name != ""? var.synapse_sppool_name : "${var.prefix}${var.environment_tag}synsp${var.app_name}")
   synapse_resource_group_name  = "managed-${module.naming.resource_group.name_unique}-synapse"
 
   tags = {

--- a/solution/DeploymentV2/terraform/modules/data_factory_datasets/arm/GDS_AzureBlobFS_DelimitedText.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_datasets/arm/GDS_AzureBlobFS_DelimitedText.json
@@ -50,7 +50,7 @@
 					"StorageAccountContainerName": {
 						"type": "String"
 					},
-					"FirstRownAsHeader": {
+					"FirstRowAsHeader": {
 						"type": "bool"
 					}
 				},
@@ -78,7 +78,7 @@
 					"columnDelimiter": ",",
 					"escapeChar": "\\",
 					"firstRowAsHeader": {
-						"value": "@dataset().FirstRownAsHeader",
+						"value": "@dataset().FirstRowAsHeader",
 						"type": "Expression"
 					},
 					"quoteChar": "\""

--- a/solution/DeploymentV2/terraform/modules/data_factory_datasets/arm/GDS_FileServer_Binary.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_datasets/arm/GDS_FileServer_Binary.json
@@ -1,0 +1,93 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "type": "String",
+            "metadata": "name of the resource"
+        },
+        "dataFactoryName": {
+            "type": "String",
+            "metadata": "Data Factory name",
+            "defaultValue": "arkstgdfads"
+        },
+        "linkedServiceName": {
+            "type": "String",
+            "metadata": "The name of the linked service that this dataset uses"
+        },
+        "integrationRuntimeName": {
+            "type": "String",
+            "metadata": "The name of the integration runtime this dataset uses"
+        }
+
+    },
+    "resources": [
+        {
+            "apiVersion": "2018-06-01",
+            "name": "[concat(parameters('dataFactoryName'), '/', parameters('name'))]",
+		"properties": {
+			"linkedServiceName": {
+				"referenceName": "GenericFileServer_IRB",
+				"type": "LinkedServiceReference",
+				"parameters": {
+					"Host": {
+						"value": "@dataset().Host",
+						"type": "Expression"
+					},
+					"UserId": {
+						"value": "@dataset().UserId",
+						"type": "Expression"
+					},
+					"Secret": {
+						"value": "@dataset().Secret",
+						"type": "Expression"
+					},
+					"KeyVaultBaseUrl": {
+						"value": "@dataset().KeyVaultBaseUrl",
+						"type": "Expression"
+					}
+				}
+			},
+			"parameters": {
+				"Host": {
+					"type": "string"
+				},
+				"UserId": {
+					"type": "string"
+				},
+				"Secret": {
+					"type": "string"
+				},
+				"Directory": {
+					"type": "string"
+				},
+				"File": {
+					"type": "string"
+				},
+				"KeyVaultBaseUrl": {
+					"type": "string"
+				}
+			},
+			"folder": {
+				"name": "[concat('ADS Go Fast/Generic/', parameters('integrationRuntimeName'))]"
+			},
+			"annotations": [],
+			"type": "Binary",
+			"typeProperties": {
+				"location": {
+					"type": "FileServerLocation",
+					"fileName": {
+						"value": "@dataset().File",
+						"type": "Expression"
+					},
+					"folderPath": {
+						"value": "@dataset().Directory",
+						"type": "Expression"
+					}
+				}
+			}
+		},
+		"type": "Microsoft.DataFactory/factories/datasets"
+	}
+	]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_datasets/main.tf
+++ b/solution/DeploymentV2/terraform/modules/data_factory_datasets/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_resource_group_template_deployment" "blob_dataset" {
   for_each            = {
     for ir in fileset(path.module, "arm/GDS_AzureBlobStorage*.json"):  
     ir => ir 
-    if var.is_azure == true
+    # if var.is_azure == true
   }
   name                = "${replace(replace(each.value, ".json", ""), "arm/", "")}_${var.integration_runtime_short_name}_${var.name_suffix}"
   resource_group_name = var.resource_group_name
@@ -104,7 +104,7 @@ resource "azurerm_resource_group_template_deployment" "mssql_dataset" {
 
 resource "azurerm_resource_group_template_deployment" "file_dataset" {
   for_each            = {
-    for ir in fileset(path.module, "arm/File*.json"):  
+    for ir in fileset(path.module, "arm/GDS_File*.json"):  
     ir => ir 
     if var.is_azure == false
   }

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_AzureBlobFS_Parquet_Full_Load.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_AzureBlobFS_Parquet_Full_Load.json
@@ -1,0 +1,378 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - Copy Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Set SQLStatement",
+                  "type": "SetVariable",
+                  "typeProperties": {
+                     "value": {
+                        "type": "Expression",
+                        "value": "@replace(replace(pipeline().parameters.TaskObject.Source.SQLStatement,'<batchcount>',string(pipeline().parameters.BatchCount)),'<item>',string(pipeline().parameters.Item))"
+                     },
+                     "variableName": "SQLStatement"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Set SQLStatement",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy SQL to Storage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@variables('SQLStatement')"
+                        },
+                        "type": "AzureSqlSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.Mapping"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy SQL to Storage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Get Parquet Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', \n string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer), \n '\",\"StorageAccountContainer\":\"', \n string(pipeline().parameters.TaskObject.Target.System.Container), \n '\",\"RelativePath\":\"', \n string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n '\",\"SchemaFileName\":\"', \n string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n '\",\"SourceType\":\"', \n string(pipeline().parameters.TaskObject.Source.System.Type), \n '\",\"TargetType\":\"', \n if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'),  \n '\",\"Data\":',\n string(activity('Get Parquet Metadata').output),\n ',\"MetadataType\":\"Parquet\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Get Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "GetMetadata",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "fieldList": [
+                        "structure"
+                     ],
+                     "storeSettings": {
+                        "recursive": true,
+                        "type": "AzureBlobFSReadSettings"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - Copy Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy SQL to Storage').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Item": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_AzureBlobFS_Parquet_Watermark.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_AzureBlobFS_Parquet_Watermark.json
@@ -1,0 +1,381 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - Copy Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Set SQLStatement",
+                  "type": "SetVariable",
+                  "typeProperties": {
+                     "value": {
+                        "type": "Expression",
+                        "value": "@replace(\n replace(\n  replace(\n   pipeline().parameters.TaskObject.Source.SQLStatement,\n   '<batchcount>',\n   string(pipeline().parameters.BatchCount)\n   ),\n '<item>',string(pipeline().parameters.Item)),\n '<newWatermark>',string(pipeline().parameters.NewWaterMark)\n)"
+                     },
+                     "variableName": "SQLStatement"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Set SQLStatement",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy SQL to Storage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@variables('SQLStatement')"
+                        },
+                        "type": "AzureSqlSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.Mapping"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy SQL to Storage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Get Parquet Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat(\n '{\"TaskInstanceId\":\"', \n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', \n string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer), \n '\",\"StorageAccountContainer\":\"', \n string(pipeline().parameters.TaskObject.Target.System.Container), \n '\",\"RelativePath\":\"', \n string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n '\",\"SchemaFileName\":\"', \n string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n '\",\"SourceType\":\"', \n string(pipeline().parameters.TaskObject.Source.System.Type), \n '\",\"TargetType\":\"', \n if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'), \n '\",\"Data\":',\n string(activity('Get Parquet Metadata').output),\n ',\"MetadataType\":\"Parquet\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Get Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "GetMetadata",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "fieldList": [
+                        "structure"
+                     ],
+                     "storeSettings": {
+                        "recursive": true,
+                        "type": "AzureBlobFSReadSettings"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - Copy Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy SQL to Storage').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Item": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "NewWaterMark": {
+                  "type": "string"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_AzureBlobStorage_Parquet_Full_Load.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_AzureBlobStorage_Parquet_Full_Load.json
@@ -1,0 +1,378 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - Copy Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Set SQLStatement",
+                  "type": "SetVariable",
+                  "typeProperties": {
+                     "value": {
+                        "type": "Expression",
+                        "value": "@replace(replace(pipeline().parameters.TaskObject.Source.SQLStatement,'<batchcount>',string(pipeline().parameters.BatchCount)),'<item>',string(pipeline().parameters.Item))"
+                     },
+                     "variableName": "SQLStatement"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Set SQLStatement",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy SQL to Storage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@variables('SQLStatement')"
+                        },
+                        "type": "AzureSqlSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.Mapping"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy SQL to Storage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Get Parquet Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', \n string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer), \n '\",\"StorageAccountContainer\":\"', \n string(pipeline().parameters.TaskObject.Target.System.Container), \n '\",\"RelativePath\":\"', \n string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n '\",\"SchemaFileName\":\"', \n string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n '\",\"SourceType\":\"', \n string(pipeline().parameters.TaskObject.Source.System.Type), \n '\",\"TargetType\":\"', \n if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'),  \n '\",\"Data\":',\n string(activity('Get Parquet Metadata').output),\n ',\"MetadataType\":\"Parquet\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Get Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "GetMetadata",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "fieldList": [
+                        "structure"
+                     ],
+                     "storeSettings": {
+                        "recursive": true,
+                        "type": "AzureBlobFSReadSettings"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - Copy Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy SQL to Storage').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Item": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_AzureBlobStorage_Parquet_Watermark.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_AzureBlobStorage_Parquet_Watermark.json
@@ -1,0 +1,381 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - Copy Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Set SQLStatement",
+                  "type": "SetVariable",
+                  "typeProperties": {
+                     "value": {
+                        "type": "Expression",
+                        "value": "@replace(\n replace(\n  replace(\n   pipeline().parameters.TaskObject.Source.SQLStatement,\n   '<batchcount>',\n   string(pipeline().parameters.BatchCount)\n   ),\n '<item>',string(pipeline().parameters.Item)),\n '<newWatermark>',string(pipeline().parameters.NewWaterMark)\n)"
+                     },
+                     "variableName": "SQLStatement"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Set SQLStatement",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy SQL to Storage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@variables('SQLStatement')"
+                        },
+                        "type": "AzureSqlSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.Mapping"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy SQL to Storage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Get Parquet Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat(\n '{\"TaskInstanceId\":\"', \n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', \n string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer), \n '\",\"StorageAccountContainer\":\"', \n string(pipeline().parameters.TaskObject.Target.System.Container), \n '\",\"RelativePath\":\"', \n string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n '\",\"SchemaFileName\":\"', \n string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n '\",\"SourceType\":\"', \n string(pipeline().parameters.TaskObject.Source.System.Type), \n '\",\"TargetType\":\"', \n if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'), \n '\",\"Data\":',\n string(activity('Get Parquet Metadata').output),\n ',\"MetadataType\":\"Parquet\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Get Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "GetMetadata",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "fieldList": [
+                        "structure"
+                     ],
+                     "storeSettings": {
+                        "recursive": true,
+                        "type": "AzureBlobFSReadSettings"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - Copy Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy SQL to Storage').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Item": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "NewWaterMark": {
+                  "type": "string"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_Create_Table.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_Create_Table.json
@@ -1,0 +1,285 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_Create_Table_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "If exist Staging TableName",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@not(empty(pipeline().parameters.TaskObject.Target.TableName))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get SQL Create Statement Staging",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TableSchema\":\"',string(pipeline().parameters.TaskObject.Target.TableSchema), '\",\"TableName\":\"', string(pipeline().parameters.TaskObject.Target.TableName),'\",\"StorageAccountName\":\"', string(pipeline().parameters.TaskObject.Source.System.SystemServer), '\",\"StorageAccountContainer\":\"', string(pipeline().parameters.TaskObject.Source.System.Container), '\",\"RelativePath\":\"', string(pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath), '\",\"SchemaFileName\":\"', string(pipeline().parameters.TaskObject.Source.SchemaFileName), '\"}'))"
+                              },
+                              "functionName": "GetSQLCreateStatementFromSchema",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "AF Get SQL Create Statement Staging",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "name": "Lookup Create Staging Table",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "Lookup",
+                           "typeProperties": {
+                              "dataset": {
+                                 "parameters": {
+                                    "Database": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                                    },
+                                    "Schema": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.StagingTableSchema"
+                                    },
+                                    "Server": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                                    },
+                                    "Table": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.StagingTableName"
+                                    }
+                                 },
+                                 "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "DatasetReference"
+                              },
+                              "firstRowOnly": false,
+                              "source": {
+                                 "partitionOption": "None",
+                                 "queryTimeout": "02:00:00",
+                                 "sqlReaderQuery": {
+                                    "type": "Expression",
+                                    "value": "@activity('AF Get SQL Create Statement Staging').output.CreateStatement"
+                                 },
+                                 "type": "AzureSqlSource"
+                              }
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Lookup Create Staging Table",
+                                 "dependencyConditions": [
+                                    "Failed"
+                                 ]
+                              }
+                           ],
+                           "name": "AF Log - Create Staging Table Failed",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "Body": {
+                                    "type": "Expression",
+                                    "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Create Staging Table\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Lookup Create Staging Table').error.message), '\",\"Status\":\"Failed\"}'))"
+                                 },
+                                 "FunctionName": "Log",
+                                 "Method": "Post"
+                              },
+                              "pipeline": {
+                                 "referenceName": "SPL_AzureFunction",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": false
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "If exist Target TableName",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@not(empty(pipeline().parameters.TaskObject.Target.StagingTableName))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get SQL Create Statement Target",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TableSchema\":\"',string(pipeline().parameters.TaskObject.Target.StagingTableSchema), '\",\"TableName\":\"', string(pipeline().parameters.TaskObject.Target.StagingTableName),'\",\"StorageAccountName\":\"', string(pipeline().parameters.TaskObject.Source.System.SystemServer), '\",\"StorageAccountContainer\":\"', string(pipeline().parameters.TaskObject.Source.System.Container), '\",\"RelativePath\":\"', string(pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath), '\",\"SchemaFileName\":\"', string(pipeline().parameters.TaskObject.Source.SchemaFileName), '\",\"DropIfExist\":\"True\"}'))"
+                              },
+                              "functionName": "GetSQLCreateStatementFromSchema",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "AF Get SQL Create Statement Target",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "name": "Lookup Create Target Table",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "Lookup",
+                           "typeProperties": {
+                              "dataset": {
+                                 "parameters": {
+                                    "Database": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                                    },
+                                    "Schema": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.TableSchema"
+                                    },
+                                    "Server": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                                    },
+                                    "Table": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.TableName"
+                                    }
+                                 },
+                                 "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "DatasetReference"
+                              },
+                              "firstRowOnly": false,
+                              "source": {
+                                 "partitionOption": "None",
+                                 "queryTimeout": "02:00:00",
+                                 "sqlReaderQuery": {
+                                    "type": "Expression",
+                                    "value": "@activity('AF Get SQL Create Statement Target').output.CreateStatement"
+                                 },
+                                 "type": "AzureSqlSource"
+                              }
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Lookup Create Target Table",
+                                 "dependencyConditions": [
+                                    "Failed"
+                                 ]
+                              }
+                           ],
+                           "name": "AF Log - Create Target Table Failed",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "Body": {
+                                    "type": "Expression",
+                                    "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Create Target Table\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Lookup Create Target Table').error.message), '\",\"Status\":\"Failed\"}'))"
+                                 },
+                                 "FunctionName": "Log",
+                                 "Method": "Post"
+                              },
+                              "pipeline": {
+                                 "referenceName": "SPL_AzureFunction",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": false
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-04T13:09:30Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_Post_Copy.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL0_AzureSqlTable_NA_Post_Copy.json
@@ -1,0 +1,582 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_Post_Copy_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "If Exist PostCopySQL",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@not(empty(pipeline().parameters.TaskObject.Target.PostCopySQL))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Run PostCopySQL",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "Lookup",
+                           "typeProperties": {
+                              "dataset": {
+                                 "parameters": {
+                                    "Database": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                                    },
+                                    "Schema": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.TableSchema"
+                                    },
+                                    "Server": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                                    },
+                                    "Table": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.TableName"
+                                    }
+                                 },
+                                 "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "DatasetReference"
+                              },
+                              "source": {
+                                 "partitionOption": "None",
+                                 "queryTimeout": "02:00:00",
+                                 "sqlReaderQuery": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject.Target.PostCopySQL"
+                                 },
+                                 "type": "AzureSqlSource"
+                              }
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Run PostCopySQL",
+                                 "dependencyConditions": [
+                                    "Failed"
+                                 ]
+                              }
+                           ],
+                           "name": "AF Log - Run PostCopySQL Failed",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "Body": {
+                                    "type": "Expression",
+                                    "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Run PostCopySQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Run PostCopySQL').error.message), '\",\"Status\":\"Failed\"}'))"
+                                 },
+                                 "FunctionName": "Log",
+                                 "Method": "Post"
+                              },
+                              "pipeline": {
+                                 "referenceName": "SPL_AzureFunction",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": false
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "If Exist PostCopySQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "If Exist MergeSQL",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@not(empty(pipeline().parameters.TaskObject.Target.MergeSQL))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Run MergeSQL",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "Lookup",
+                           "typeProperties": {
+                              "dataset": {
+                                 "parameters": {
+                                    "Database": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                                    },
+                                    "Schema": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.TableSchema"
+                                    },
+                                    "Server": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                                    },
+                                    "Table": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.TableName"
+                                    }
+                                 },
+                                 "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "DatasetReference"
+                              },
+                              "firstRowOnly": true,
+                              "source": {
+                                 "partitionOption": "None",
+                                 "queryTimeout": "02:00:00",
+                                 "sqlReaderQuery": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject.Target.MergeSQL"
+                                 },
+                                 "type": "AzureSqlSource"
+                              }
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Run MergeSQL",
+                                 "dependencyConditions": [
+                                    "Failed"
+                                 ]
+                              }
+                           ],
+                           "name": "AF Log - Run MergeSQL Failed",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "Body": {
+                                    "type": "Expression",
+                                    "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Run MergeSQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Run MergeSQL').error.message), '\",\"Status\":\"Failed\"}'))"
+                                 },
+                                 "FunctionName": "Log",
+                                 "Method": "Post"
+                              },
+                              "pipeline": {
+                                 "referenceName": "SPL_AzureFunction",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": false
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "If Exist PostCopySQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "If AutoGenerateMerge",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@bool(pipeline().parameters.TaskObject.Target.AutoGenerateMerge)"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "AF Get Merge Statement",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "name": "Run MergeStatement",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "Lookup",
+                           "typeProperties": {
+                              "dataset": {
+                                 "parameters": {
+                                    "Database": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                                    },
+                                    "Schema": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.TableSchema"
+                                    },
+                                    "Server": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                                    },
+                                    "Table": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.TableName"
+                                    }
+                                 },
+                                 "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "DatasetReference"
+                              },
+                              "firstRowOnly": false,
+                              "source": {
+                                 "partitionOption": "None",
+                                 "queryTimeout": "02:00:00",
+                                 "sqlReaderQuery": {
+                                    "type": "Expression",
+                                    "value": "@activity('AF Get Merge Statement').output.MergeStatement"
+                                 },
+                                 "type": "AzureSqlSource"
+                              }
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [ ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Information Schema SQL Stage",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TableSchema\":\"', string(pipeline().parameters.TaskObject.Target.StagingTableSchema), '\",\"TableName\":\"', string(pipeline().parameters.TaskObject.Target.StagingTableName),'\"}'))"
+                              },
+                              "functionName": "GetInformationSchemaSQL",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Lookup Get Metadata Stage",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              },
+                              {
+                                 "activity": "Lookup Get Metadata Target",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Merge Statement",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId),'\",\"TargetTableSchema\":\"',string(pipeline().parameters.TaskObject.Target.TableSchema),'\",\"TargetTableName\":\"',string(pipeline().parameters.TaskObject.Target.TableName),'\",\"StagingTableSchema\":\"',string(pipeline().parameters.TaskObject.Target.StagingTableSchema),'\",\"StagingTableName\":\"',string(pipeline().parameters.TaskObject.Target.StagingTableName),'\",\"Stage\":', string(activity('Lookup Get Metadata Stage').output.value), ',\"Target\":', string(activity('Lookup Get Metadata Target').output.value),'}'))"
+                              },
+                              "functionName": "GetSQLMergeStatement",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "AF Get Information Schema SQL Stage",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "name": "Lookup Get Metadata Stage",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "Lookup",
+                           "typeProperties": {
+                              "dataset": {
+                                 "parameters": {
+                                    "Database": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                                    },
+                                    "Schema": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.StagingTableSchema"
+                                    },
+                                    "Server": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                                    },
+                                    "Table": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.StagingTableName"
+                                    }
+                                 },
+                                 "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "DatasetReference"
+                              },
+                              "firstRowOnly": false,
+                              "source": {
+                                 "partitionOption": "None",
+                                 "queryTimeout": "02:00:00",
+                                 "sqlReaderQuery": {
+                                    "type": "Expression",
+                                    "value": "@activity('AF Get Information Schema SQL Stage').output.InformationSchemaSQL"
+                                 },
+                                 "type": "AzureSqlSource"
+                              }
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "AF Get Information Schema SQL Target",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "name": "Lookup Get Metadata Target",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "Lookup",
+                           "typeProperties": {
+                              "dataset": {
+                                 "parameters": {
+                                    "Database": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                                    },
+                                    "Schema": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.TableSchema"
+                                    },
+                                    "Server": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                                    },
+                                    "Table": {
+                                       "type": "Expression",
+                                       "value": "@pipeline().parameters.TaskObject.Target.TableName"
+                                    }
+                                 },
+                                 "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "DatasetReference"
+                              },
+                              "firstRowOnly": false,
+                              "source": {
+                                 "partitionOption": "None",
+                                 "queryTimeout": "02:00:00",
+                                 "sqlReaderQuery": {
+                                    "type": "Expression",
+                                    "value": "@activity('AF Get Information Schema SQL Target').output.InformationSchemaSQL"
+                                 },
+                                 "type": "AzureSqlSource"
+                              }
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [ ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Information Schema SQL Target",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TableSchema\":\"', string(pipeline().parameters.TaskObject.Target.TableSchema), '\",\"TableName\":\"', string(pipeline().parameters.TaskObject.Target.TableName),'\"}'))"
+                              },
+                              "functionName": "GetInformationSchemaSQL",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Run MergeStatement",
+                                 "dependencyConditions": [
+                                    "Failed"
+                                 ]
+                              }
+                           ],
+                           "name": "AF Log - Run AutoMerge Failed",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "Body": {
+                                    "type": "Expression",
+                                    "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Run AutoMerge\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Run MergeStatement').error.message), '\",\"Status\":\"Failed\"}'))"
+                                 },
+                                 "FunctionName": "Log",
+                                 "Method": "Post"
+                              },
+                              "pipeline": {
+                                 "referenceName": "SPL_AzureFunction",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": false
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Lookup Get Metadata Target",
+                                 "dependencyConditions": [
+                                    "Failed"
+                                 ]
+                              }
+                           ],
+                           "name": "AF Log - Run Lookup Get Metadata Target Failed",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "Body": {
+                                    "type": "Expression",
+                                    "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Lookup Get Metadata Target\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Lookup Get Metadata Target').error.message), '\",\"Status\":\"Failed\"}'))"
+                                 },
+                                 "FunctionName": "Log",
+                                 "Method": "Post"
+                              },
+                              "pipeline": {
+                                 "referenceName": "SPL_AzureFunction",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": false
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Lookup Get Metadata Stage",
+                                 "dependencyConditions": [
+                                    "Failed"
+                                 ]
+                              }
+                           ],
+                           "name": "AF Log - Lookup Get Metadata Stage Failed",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "Body": {
+                                    "type": "Expression",
+                                    "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Lookup Get Metadata Stage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Lookup Get Metadata Stage').error.message), '\",\"Status\":\"Failed\"}'))"
+                                 },
+                                 "FunctionName": "Log",
+                                 "Method": "Post"
+                              },
+                              "pipeline": {
+                                 "referenceName": "SPL_AzureFunction",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": false
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Common')]"
+            },
+            "lastPublishTime": "2020-08-04T13:09:30Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL1_AzureSqlTable_NA_AzureBlobFS_Parquet_Full_Load_Chunk.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL1_AzureSqlTable_NA_AzureBlobFS_Parquet_Full_Load_Chunk.json
@@ -1,0 +1,143 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_Full_Load_Chunk_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "ForEach Chunk",
+                  "type": "ForEach",
+                  "typeProperties": {
+                     "activities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Full Load",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "BatchCount": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.BatchCount"
+                                 },
+                                 "Item": {
+                                    "type": "Expression",
+                                    "value": "@item()"
+                                 },
+                                 "Mapping": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.Mapping"
+                                 },
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        }
+                     ],
+                     "isSequential": true,
+                     "items": {
+                        "type": "Expression",
+                        "value": "@range(1, pipeline().parameters.BatchCount)"
+                     }
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "SH-AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL1_AzureSqlTable_NA_AzureBlobFS_Parquet_Watermark_Chunk.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL1_AzureSqlTable_NA_AzureBlobFS_Parquet_Watermark_Chunk.json
@@ -1,0 +1,178 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_Watermark_Chunk_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "ForEach Chunk",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "AF Set New Watermark",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TaskMasterId\":\"', string(pipeline().parameters.TaskObject.TaskMasterId),'\",\"TaskMasterWaterMarkColumnType\":\"', string(pipeline().parameters.TaskObject.Source.IncrementalColumnType),'\",\"WaterMarkValue\":\"', string(pipeline().parameters.NewWatermark), '\"}'))"
+                        },
+                        "FunctionName": "WaterMark",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "ForEach Chunk",
+                  "type": "ForEach",
+                  "typeProperties": {
+                     "activities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Watermark",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "BatchCount": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.BatchCount"
+                                 },
+                                 "Item": {
+                                    "type": "Expression",
+                                    "value": "@item()"
+                                 },
+                                 "Mapping": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.Mapping"
+                                 },
+                                 "NewWaterMark": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.NewWatermark"
+                                 },
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        }
+                     ],
+                     "isSequential": true,
+                     "items": {
+                        "type": "Expression",
+                        "value": "@range(1, pipeline().parameters.BatchCount)"
+                     }
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "NewWatermark": {
+                  "type": "string"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL1_AzureSqlTable_NA_AzureBlobStorage_Parquet_Full_Load_Chunk.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL1_AzureSqlTable_NA_AzureBlobStorage_Parquet_Full_Load_Chunk.json
@@ -1,0 +1,143 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_Full_Load_Chunk_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "ForEach Chunk",
+                  "type": "ForEach",
+                  "typeProperties": {
+                     "activities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Full Load",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "BatchCount": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.BatchCount"
+                                 },
+                                 "Item": {
+                                    "type": "Expression",
+                                    "value": "@item()"
+                                 },
+                                 "Mapping": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.Mapping"
+                                 },
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        }
+                     ],
+                     "isSequential": true,
+                     "items": {
+                        "type": "Expression",
+                        "value": "@range(1, pipeline().parameters.BatchCount)"
+                     }
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "SH-AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL1_AzureSqlTable_NA_AzureBlobStorage_Parquet_Watermark_Chunk.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL1_AzureSqlTable_NA_AzureBlobStorage_Parquet_Watermark_Chunk.json
@@ -1,0 +1,178 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_Watermark_Chunk_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "ForEach Chunk",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "AF Set New Watermark",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TaskMasterId\":\"', string(pipeline().parameters.TaskObject.TaskMasterId),'\",\"TaskMasterWaterMarkColumnType\":\"', string(pipeline().parameters.TaskObject.Source.IncrementalColumnType),'\",\"WaterMarkValue\":\"', string(pipeline().parameters.NewWatermark), '\"}'))"
+                        },
+                        "FunctionName": "WaterMark",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "ForEach Chunk",
+                  "type": "ForEach",
+                  "typeProperties": {
+                     "activities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Watermark",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "BatchCount": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.BatchCount"
+                                 },
+                                 "Item": {
+                                    "type": "Expression",
+                                    "value": "@item()"
+                                 },
+                                 "Mapping": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.Mapping"
+                                 },
+                                 "NewWaterMark": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.NewWatermark"
+                                 },
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        }
+                     ],
+                     "isSequential": true,
+                     "items": {
+                        "type": "Expression",
+                        "value": "@range(1, pipeline().parameters.BatchCount)"
+                     }
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "NewWatermark": {
+                  "type": "string"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Binary_AzureBlobFS_Binary.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Binary_AzureBlobFS_Binary.json
@@ -6,30 +6,29 @@
          "metadata": "The name of the data factory",
          "type": "String"
       },
-      "integrationRuntimeShortName": {
-         "metadata": "The short name of the integration runtime this pipeline uses",
-         "type": "String"
-      },
       "integrationRuntimeName": {
          "metadata": "The name of the integration runtime this pipeline uses",
          "type": "String"
       },
-      "sharedKeyVaultUri" : {
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
          "metadata": "The uri of the shared KeyVault",
          "type": "String"
       }
-      
    },
    "resources": [
       {
          "apiVersion": "2018-06-01",
-         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_AzureBlobFS_', parameters('integrationRuntimeShortName'))]",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Binary_AzureBlobFS_Binary_', parameters('integrationRuntimeShortName'))]",
          "properties": {
             "activities": [
                {
                   "dependsOn": [
                      {
-                        "activity": "Pipeline AF Log - AzureBlobFS to AzureBlobFS Start",
+                        "activity": "Copy AzureBlobFS to AzureBlobFS Started",
                         "dependencyConditions": [
                            "Succeeded"
                         ]
@@ -48,11 +47,11 @@
                            },
                            "FileSystem": {
                               "type": "Expression",
-                              "value": "@pipeline().parameters.TaskObject.Source.StorageAccountContainer"
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
                            },
                            "StorageAccountEndpoint": {
                               "type": "Expression",
-                              "value": "@pipeline().parameters.TaskObject.Source.StorageAccountName"
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
                            }
                         },
                         "referenceName": "[concat('GDS_AzureBlobFS_Binary_', parameters('integrationRuntimeShortName'))]",
@@ -73,11 +72,11 @@
                            },
                            "FileSystem": {
                               "type": "Expression",
-                              "value": "@pipeline().parameters.TaskObject.Target.StorageAccountContainer"
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
                            },
                            "StorageAccountEndpoint": {
                               "type": "Expression",
-                              "value": "@pipeline().parameters.TaskObject.Target.StorageAccountName"
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
                            }
                         },
                         "referenceName": "[concat('GDS_AzureBlobFS_Binary_', parameters('integrationRuntimeShortName'))]",
@@ -106,13 +105,13 @@
                         "type": "BinarySink"
                      },
                      "source": {
-                        "formatSettings": {
-                           "type": "BinaryReadSettings"
-                        },
                         "storeSettings": {
                            "deleteFilesAfterCompletion": {
                               "type": "Expression",
                               "value": "@pipeline().parameters.TaskObject.Source.DeleteAfterCompletion"
+                           },
+                           "formatSettings": {
+                              "type": "BinaryReadSettings"
                            },
                            "recursive": {
                               "type": "Expression",
@@ -138,7 +137,7 @@
                         ]
                      }
                   ],
-                  "name": "Pipeline AF Log - AzureBlobFS to AzureBlobFS Failed",
+                  "name": "Copy AzureBlobFS to AzureBlobFS Failed",
                   "type": "ExecutePipeline",
                   "typeProperties": {
                      "parameters": {
@@ -150,7 +149,7 @@
                         "Method": "Post"
                      },
                      "pipeline": {
-                        "referenceName": "GPL_AzureFunction_Common",
+                        "referenceName": "SPL_AzureFunction",
                         "type": "PipelineReference"
                      },
                      "waitOnCompletion": false
@@ -159,19 +158,19 @@
                },
                {
                   "dependsOn": [ ],
-                  "name": "Pipeline AF Log - AzureBlobFS to AzureBlobFS Start",
+                  "name": "Copy AzureBlobFS to AzureBlobFS Started",
                   "type": "ExecutePipeline",
                   "typeProperties": {
                      "parameters": {
                         "Body": {
                            "type": "Expression",
-                           "value": "@json('{  \"TaskInstanceId\":\"@string(pipeline().parameters.TaskObject.TaskInstanceId)\",  \"ExecutionUid\":\"@string(pipeline().parameters.TaskObject.ExecutionUid)\",  \"RunId\":\"@string(pipeline().RunId)\",  \"LogTypeId\":3,  \"LogSource\":\"ADF\",  \"ActivityType\":\"Copy Blob to Blob\",  \"StartDateTimeOffSet\":\"@string(pipeline().TriggerTime)\",  \"Status\":\"Started\"}')"
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
                         },
                         "FunctionName": "Log",
                         "Method": "Post"
                      },
                      "pipeline": {
-                        "referenceName": "GPL_AzureFunction_Common",
+                        "referenceName": "SPL_AzureFunction",
                         "type": "PipelineReference"
                      },
                      "waitOnCompletion": false
@@ -187,7 +186,7 @@
                         ]
                      }
                   ],
-                  "name": "Pipeline AF Log - AzureBlobFS to AzureBlobFS Succeed",
+                  "name": "Copy AzureBlobFS to AzureBlobFS Succeed",
                   "type": "ExecutePipeline",
                   "typeProperties": {
                      "parameters": {
@@ -199,22 +198,77 @@
                         "Method": "Post"
                      },
                      "pipeline": {
-                        "referenceName": "GPL_AzureFunction_Common",
+                        "referenceName": "SPL_AzureFunction",
                         "type": "PipelineReference"
                      },
                      "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
                   },
                   "userProperties": [ ]
                }
             ],
             "annotations": [ ],
             "folder": {
-               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeName'))]"
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
             },
             "lastPublishTime": "2020-08-05T04:14:00Z",
             "parameters": {
                "TaskObject": {
-                  "defaultValue": "[concat('[[   {     \"TaskInstanceId\": 2,     \"TaskMasterId\": 1,     \"TaskStatus\": \"Untried\",     \"TaskType\": \"AzureStorageToAzureStorage_IRA\",     \"Enabled\": true,     \"ExecutionUid\": 1,     \"KeyVaultBaseUrl\": \"', parameters('sharedKeyVaultUri'), '\",     \"Source\": {       \"StorageAccountName\": \"https://adsgofastdatalakeadls.dfs.core.windows.net\",       \"Type\": \"ADLS\",       \"StorageAccountContainer\": \"datalakelanding\",       \"StorageAccountAccessMethod\": \"MSI\",       \"StorageAccountSASUriKeyVaultSecretName\": null,       \"RelativePath\": \"/Unprocessed/adsgofastdatakakeaccelsqlsvr/AWSample/SalesLT/2020/06/08/17/\",       \"DataFileName\": \"Customer_Data.parquet\",       \"SchemaFileName\": \"Customer_Schema.json\"     },     \"Target\": {       \"StorageAccountName\": \"https://adsgofastdatalakeadls.dfs.core.windows.net\",       \"Type\": \"ADLS\",       \"StorageAccountContainer\": \"datalakelanding\",       \"StorageAccountAccessMethod\": \"MSI\",       \"StorageAccountSASUriKeyVaultSecretName\": null,       \"RelativePath\": \"/Processed/adsgofastdatakakeaccelsqlsvr/AWSample/SalesLT/2020/06/08/17/\",       \"DataFileName\": \"Customer_Data.parquet\",       \"SchemaFileName\": \"Customer_Schema.json\"     },     \"DataFactory\": {       \"Id\": 1,       \"Name\": \"adsgofastdatakakeacceladf\",       \"ResourceGroup\": \"AdsGoFastDataLakeAccel\",       \"SubscriptionId\": \"035a1364-f00d-48e2-b582-4fe125905ee3\",     }   } ]]')]",
                   "type": "object"
                }
             }

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Binary_AzureBlobStorage_Binary.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Binary_AzureBlobStorage_Binary.json
@@ -1,0 +1,279 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Binary_AzureBlobStorage_Binary_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Directory": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "File": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FileSystem": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Binary_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Directory": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "File": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FileSystem": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Binary_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "BinarySink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "deleteFilesAfterCompletion": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DeleteAfterCompletion"
+                           },
+                           "formatSettings": {
+                              "type": "BinaryReadSettings"
+                           },
+                           "recursive": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Recursively"
+                           },
+                           "type": "AzureBlobFSReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           }
+                        },
+                        "type": "BinarySource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobFS to AzureBlobStorage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobFS to AzureBlobStorage').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_DelimitedText_AzureBlobFS_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_DelimitedText_AzureBlobFS_Parquet.json
@@ -1,0 +1,289 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_DelimitedText_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "enablePartitionDiscovery": false,
+                           "formatSettings": {
+                              "skipLineCount": {
+                                 "type": "Expression",
+                                 "value": "@pipeline().parameters.TaskObject.Source.SkipLineCount"
+                              },
+                              "type": "DelimitedTextReadSettings"
+                           },
+                           "maxConcurrentConnections": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.MaxConcorrentConnections"
+                           },
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "wildcardFolderPath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           }
+                        },
+                        "type": "DelimitedTextSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobFS to AzureBlobFS').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobFS to AzureBlobFS').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_DelimitedText_AzureBlobStorage_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_DelimitedText_AzureBlobStorage_Parquet.json
@@ -1,0 +1,289 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_DelimitedText_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "enablePartitionDiscovery": false,
+                           "formatSettings": {
+                              "skipLineCount": {
+                                 "type": "Expression",
+                                 "value": "@pipeline().parameters.TaskObject.Source.SkipLineCount"
+                              },
+                              "type": "DelimitedTextReadSettings"
+                           },
+                           "maxConcurrentConnections": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.MaxConcorrentConnections"
+                           },
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "wildcardFolderPath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           }
+                        },
+                        "type": "DelimitedTextSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobFS to AzureBlobStorage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobFS to AzureBlobStorage').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_DelimitedText_AzureSqlTable_NA.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_DelimitedText_AzureSqlTable_NA.json
@@ -1,0 +1,406 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_DelimitedText_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "description": "Auto Creates Table Using a Schema File",
+                  "name": "If Auto Create Table",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Create Table",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_Create_Table_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Execute Create Table",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Mapping",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n  string(pipeline().parameters.TaskObject.TaskInstanceId), \n  '\",\"ExecutionUid\":\"', \n  string(pipeline().parameters.TaskObject.ExecutionUid), \n  '\",\"RunId\":\"', \n  string(pipeline().RunId), \n  '\",\"StorageAccountName\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.SystemServer), \n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Source.SchemaFileName), \n  '\",\"SourceType\":\"', \n  if(\n     contains(string(pipeline().parameters.TaskObject.Source.System.SystemServer),'.dfs.core.windows.net'),\n     'ADLS',\n     'Azure Blob'\n    ), \n  '\",\"TargetType\":\"', \n  string(pipeline().parameters.TaskObject.Target.Type), \n  '\",\"MetadataType\":\"Parquet\"}')\n)"
+                              },
+                              "functionName": "GetSourceTargetMapping",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy to SQL",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "disableMetricsCollection": false,
+                        "preCopyScript": {
+                           "type": "Expression",
+                           "value": "@{pipeline().parameters.TaskObject.Target.PreCopySQL}"
+                        },
+                        "tableOption": "autoCreate",
+                        "type": "AzureSqlSink"
+                     },
+                     "source": {
+                        "formatSettings": {
+                           "skipLineCount": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SkipLineCount"
+                           },
+                           "type": "DelimitedTextReadSettings"
+                        },
+                        "storeSettings": {
+                           "enablePartitionDiscovery": false,
+                           "maxConcurrentConnections": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.MaxConcorrentConnections"
+                           },
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "wildcardFolderPath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           }
+                        },
+                        "type": "DelimitedTextSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.Target.DynamicMapping"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy to SQL').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy to SQL').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Execute AZ_SQL_Post-Copy",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "TaskObject": {
+                           "type": "Expression",
+                           "value": "@pipeline().parameters.TaskObject"
+                        }
+                     },
+                     "pipeline": {
+                        "referenceName": "[concat('GPL_AzureSqlTable_NA_Post_Copy_', parameters('integrationRuntimeShortName'))]",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-07-29T09:43:40Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Excel_AzureBlobFS_DelimitedText.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Excel_AzureBlobFS_DelimitedText.json
@@ -1,0 +1,282 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Excel_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "SheetName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SheetName"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Excel_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "formatSettings": {
+                              "fileExtension": ".txt",
+                              "quoteAllText": true,
+                              "type": "DelimitedTextWriteSettings"
+                           },
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "DelimitedTextSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings"
+                        },
+                        "type": "ExcelSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobFS to AzureBlobFS').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobFS to AzureBlobFS').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Excel_AzureBlobFS_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Excel_AzureBlobFS_Parquet.json
@@ -1,0 +1,273 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Excel_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "SheetName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SheetName"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Excel_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings"
+                        },
+                        "type": "ExcelSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobFS to AzureBlobFS').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobFS to AzureBlobFS').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Excel_AzureBlobStorage_DelimitedText.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Excel_AzureBlobStorage_DelimitedText.json
@@ -1,0 +1,282 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Excel_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "SheetName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SheetName"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Excel_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "formatSettings": {
+                              "fileExtension": ".txt",
+                              "quoteAllText": true,
+                              "type": "DelimitedTextWriteSettings"
+                           },
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "DelimitedTextSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings"
+                        },
+                        "type": "ExcelSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobFS to AzureBlobStorage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobFS to AzureBlobStorage').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Excel_AzureBlobStorage_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Excel_AzureBlobStorage_Parquet.json
@@ -1,0 +1,273 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Excel_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "SheetName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SheetName"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Excel_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings"
+                        },
+                        "type": "ExcelSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobFS to AzureBlobStorage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobFS to AzureBlobStorage').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Excel_AzureSqlTable_NA.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Excel_AzureSqlTable_NA.json
@@ -1,0 +1,390 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Excel_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "description": "Auto Creates Table Using a Schema File",
+                  "name": "If Auto Create Table",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Create Table",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_Create_Table_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Execute Create Table",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Mapping",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n  string(pipeline().parameters.TaskObject.TaskInstanceId), \n  '\",\"ExecutionUid\":\"', \n  string(pipeline().parameters.TaskObject.ExecutionUid), \n  '\",\"RunId\":\"', \n  string(pipeline().RunId), \n  '\",\"StorageAccountName\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.SystemServer), \n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Source.SchemaFileName), \n  '\",\"SourceType\":\"', \n  if(\n     contains(string(pipeline().parameters.TaskObject.Source.System.SystemServer),'.dfs.core.windows.net'),\n     'ADLS',\n     'Azure Blob'\n    ), \n  '\",\"TargetType\":\"', \n  string(pipeline().parameters.TaskObject.Target.Type), \n  '\",\"MetadataType\":\"Parquet\"}')\n)"
+                              },
+                              "functionName": "GetSourceTargetMapping",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           },
+                           "SheetName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SheetName"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Excel_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy to SQL",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "disableMetricsCollection": false,
+                        "preCopyScript": {
+                           "type": "Expression",
+                           "value": "@{pipeline().parameters.TaskObject.Target.PreCopySQL}"
+                        },
+                        "tableOption": "autoCreate",
+                        "type": "AzureSqlSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings"
+                        },
+                        "type": "ExcelSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@if(and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable)),activity('AF Get Mapping').output.value, null)"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy to SQL').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy to SQL').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Execute AZ_SQL_Post-Copy",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "TaskObject": {
+                           "type": "Expression",
+                           "value": "@pipeline().parameters.TaskObject"
+                        }
+                     },
+                     "pipeline": {
+                        "referenceName": "[concat('GPL_AzureSqlTable_NA_Post_Copy_', parameters('integrationRuntimeShortName'))]",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-07-29T09:43:40Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Json_AzureSqlTable_NA.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Json_AzureSqlTable_NA.json
@@ -1,0 +1,384 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Json_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "description": "Auto Creates Table Using a Schema File",
+                  "name": "If Auto Create Table",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Create Table",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_Create_Table_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Execute Create Table",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Mapping",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n  string(pipeline().parameters.TaskObject.TaskInstanceId), \n  '\",\"ExecutionUid\":\"', \n  string(pipeline().parameters.TaskObject.ExecutionUid), \n  '\",\"RunId\":\"', \n  string(pipeline().RunId), \n  '\",\"StorageAccountName\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.SystemServer), \n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Source.SchemaFileName), \n  '\",\"SourceType\":\"', \n  if(\n     contains(string(pipeline().parameters.TaskObject.Source.System.SystemServer),'.dfs.core.windows.net'),\n     'ADLS',\n     'Azure Blob'\n    ), \n  '\",\"TargetType\":\"', \n  string(pipeline().parameters.TaskObject.Target.Type), \n  '\",\"MetadataType\":\"Parquet\"}')\n)"
+                              },
+                              "functionName": "GetSourceTargetMapping",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Json_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy to SQL",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "disableMetricsCollection": false,
+                        "preCopyScript": {
+                           "type": "Expression",
+                           "value": "@{pipeline().parameters.TaskObject.Target.PreCopySQL}"
+                        },
+                        "type": "AzureSqlSink"
+                     },
+                     "source": {
+                        "formatSettings": {
+                           "type": "JsonReadSettings"
+                        },
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings"
+                        },
+                        "type": "JsonSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@if(and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable)),activity('AF Get Mapping').output.value, null)"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy to SQL').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy to SQL').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Execute AZ_SQL_Post-Copy",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "TaskObject": {
+                           "type": "Expression",
+                           "value": "@pipeline().parameters.TaskObject"
+                        }
+                     },
+                     "pipeline": {
+                        "referenceName": "[concat('GPL_AzureSqlTable_NA_Post_Copy_', parameters('integrationRuntimeShortName'))]",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-07-29T09:43:40Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Parquet_AzureBlobFS_DelimitedText.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Parquet_AzureBlobFS_DelimitedText.json
@@ -1,0 +1,274 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Parquet_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "formatSettings": {
+                              "fileExtension": ".txt",
+                              "quoteAllText": true,
+                              "type": "DelimitedTextWriteSettings"
+                           },
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "DelimitedTextSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings"
+                        },
+                        "type": "ParquetSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobFS to AzureBlobFS').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobFS Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobFS to AzureBlobFS').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Parquet_AzureBlobStorage_DelimitedText.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Parquet_AzureBlobStorage_DelimitedText.json
@@ -1,0 +1,274 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Parquet_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "formatSettings": {
+                              "fileExtension": ".txt",
+                              "quoteAllText": true,
+                              "type": "DelimitedTextWriteSettings"
+                           },
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "DelimitedTextSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobFSReadSettings"
+                        },
+                        "type": "ParquetSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobFS to AzureBlobStorage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobFS to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobFS to AzureBlobStorage Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobFS to AzureBlobStorage').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Parquet_AzureSqlTable_NA.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobFS_Parquet_AzureSqlTable_NA.json
@@ -1,0 +1,394 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobFS_Parquet_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "description": "Auto Creates Table Using a Schema File",
+                  "name": "If Auto Create Table",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Create Table",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_Create_Table_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Execute Create Table",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Mapping",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n  string(pipeline().parameters.TaskObject.TaskInstanceId), \n  '\",\"ExecutionUid\":\"', \n  string(pipeline().parameters.TaskObject.ExecutionUid), \n  '\",\"RunId\":\"', \n  string(pipeline().RunId), \n  '\",\"StorageAccountName\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.SystemServer), \n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Source.SchemaFileName), \n  '\",\"SourceType\":\"', \n  if(\n     contains(string(pipeline().parameters.TaskObject.Source.System.SystemServer),'.dfs.core.windows.net'),\n     'ADLS',\n     'Azure Blob'\n    ), \n  '\",\"TargetType\":\"', \n  string(pipeline().parameters.TaskObject.Target.Type), \n  '\",\"MetadataType\":\"Parquet\"}')\n)"
+                              },
+                              "functionName": "GetSourceTargetMapping",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy to SQL",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "disableMetricsCollection": false,
+                        "preCopyScript": {
+                           "type": "Expression",
+                           "value": "@{pipeline().parameters.TaskObject.Target.PreCopySQL}"
+                        },
+                        "tableOption": "autoCreate",
+                        "type": "AzureSqlSink"
+                     },
+                     "source": {
+                        "formatSettings": {
+                           "type": "AzureBlobFSReadSettings"
+                        },
+                        "storeSettings": {
+                           "enablePartitionDiscovery": false,
+                           "recursive": false,
+                           "type": "AzureBlobFSReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@concat(\n    replace(\n        pipeline().parameters.TaskObject.Source.DataFileName,\n        '.parquet',\n        ''\n        ),\n    '*.parquet'\n)"
+                           },
+                           "wildcardFolderPath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           }
+                        },
+                        "type": "ParquetSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@if(and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable)),activity('AF Get Mapping').output.value, null)"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy to SQL').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy to SQL').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Execute AZ_SQL_Post-Copy",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "TaskObject": {
+                           "type": "Expression",
+                           "value": "@pipeline().parameters.TaskObject"
+                        }
+                     },
+                     "pipeline": {
+                        "referenceName": "[concat('GPL_AzureSqlTable_NA_Post_Copy_', parameters('integrationRuntimeShortName'))]",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-07-29T09:43:40Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Binary_AzureBlobFS_Binary.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Binary_AzureBlobFS_Binary.json
@@ -1,0 +1,279 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Binary_AzureBlobFS_Binary_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Directory": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "File": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FileSystem": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Binary_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Directory": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "File": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FileSystem": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Binary_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "BinarySink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "deleteFilesAfterCompletion": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DeleteAfterCompletion"
+                           },
+                           "formatSettings": {
+                              "type": "BinaryReadSettings"
+                           },
+                           "recursive": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Recursively"
+                           },
+                           "type": "AzureBlobStorageReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           }
+                        },
+                        "type": "BinarySource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobStorage to AzureBlobFS').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobStorage to AzureBlobFS').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Binary_AzureBlobStorage_Binary.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Binary_AzureBlobStorage_Binary.json
@@ -1,0 +1,279 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Binary_AzureBlobStorage_Binary_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Directory": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "File": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FileSystem": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Binary_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Directory": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "File": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FileSystem": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Binary_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "BinarySink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "deleteFilesAfterCompletion": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DeleteAfterCompletion"
+                           },
+                           "formatSettings": {
+                              "type": "BinaryReadSettings"
+                           },
+                           "recursive": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Recursively"
+                           },
+                           "type": "AzureBlobStorageReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           }
+                        },
+                        "type": "BinarySource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobStorage to AzureBlobStorage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobStorage to AzureBlobStorage').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_DelimitedText_AzureBlobFS_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_DelimitedText_AzureBlobFS_Parquet.json
@@ -1,0 +1,289 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_DelimitedText_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "enablePartitionDiscovery": false,
+                           "formatSettings": {
+                              "skipLineCount": {
+                                 "type": "Expression",
+                                 "value": "@pipeline().parameters.TaskObject.Source.SkipLineCount"
+                              },
+                              "type": "DelimitedTextReadSettings"
+                           },
+                           "maxConcurrentConnections": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.MaxConcorrentConnections"
+                           },
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "wildcardFolderPath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           }
+                        },
+                        "type": "DelimitedTextSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobStorage to AzureBlobFS').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobStorage to AzureBlobFS').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_DelimitedText_AzureBlobStorage_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_DelimitedText_AzureBlobStorage_Parquet.json
@@ -1,0 +1,289 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_DelimitedText_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "enablePartitionDiscovery": false,
+                           "formatSettings": {
+                              "skipLineCount": {
+                                 "type": "Expression",
+                                 "value": "@pipeline().parameters.TaskObject.Source.SkipLineCount"
+                              },
+                              "type": "DelimitedTextReadSettings"
+                           },
+                           "maxConcurrentConnections": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.MaxConcorrentConnections"
+                           },
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "wildcardFolderPath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           }
+                        },
+                        "type": "DelimitedTextSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobStorage to AzureBlobStorage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobStorage to AzureBlobStorage').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_DelimitedText_AzureSqlTable_NA.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_DelimitedText_AzureSqlTable_NA.json
@@ -1,0 +1,406 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_DelimitedText_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "description": "Auto Creates Table Using a Schema File",
+                  "name": "If Auto Create Table",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Create Table",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_Create_Table_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Execute Create Table",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Mapping",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n  string(pipeline().parameters.TaskObject.TaskInstanceId), \n  '\",\"ExecutionUid\":\"', \n  string(pipeline().parameters.TaskObject.ExecutionUid), \n  '\",\"RunId\":\"', \n  string(pipeline().RunId), \n  '\",\"StorageAccountName\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.SystemServer), \n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Source.SchemaFileName), \n  '\",\"SourceType\":\"', \n  if(\n     contains(string(pipeline().parameters.TaskObject.Source.System.SystemServer),'.dfs.core.windows.net'),\n     'ADLS',\n     'Azure Blob'\n    ), \n  '\",\"TargetType\":\"', \n  string(pipeline().parameters.TaskObject.Target.Type), \n  '\",\"MetadataType\":\"Parquet\"}')\n)"
+                              },
+                              "functionName": "GetSourceTargetMapping",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy to SQL",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "disableMetricsCollection": false,
+                        "preCopyScript": {
+                           "type": "Expression",
+                           "value": "@{pipeline().parameters.TaskObject.Target.PreCopySQL}"
+                        },
+                        "tableOption": "autoCreate",
+                        "type": "AzureSqlSink"
+                     },
+                     "source": {
+                        "formatSettings": {
+                           "skipLineCount": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SkipLineCount"
+                           },
+                           "type": "DelimitedTextReadSettings"
+                        },
+                        "storeSettings": {
+                           "enablePartitionDiscovery": false,
+                           "maxConcurrentConnections": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.MaxConcorrentConnections"
+                           },
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "wildcardFolderPath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           }
+                        },
+                        "type": "DelimitedTextSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.Target.DynamicMapping"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy to SQL').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy to SQL').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Execute AZ_SQL_Post-Copy",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "TaskObject": {
+                           "type": "Expression",
+                           "value": "@pipeline().parameters.TaskObject"
+                        }
+                     },
+                     "pipeline": {
+                        "referenceName": "[concat('GPL_AzureSqlTable_NA_Post_Copy_', parameters('integrationRuntimeShortName'))]",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-07-29T09:43:40Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Excel_AzureBlobFS_DelimitedText.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Excel_AzureBlobFS_DelimitedText.json
@@ -1,0 +1,282 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Excel_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "SheetName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SheetName"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Excel_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "formatSettings": {
+                              "fileExtension": ".txt",
+                              "quoteAllText": true,
+                              "type": "DelimitedTextWriteSettings"
+                           },
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "DelimitedTextSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings"
+                        },
+                        "type": "ExcelSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobStorage to AzureBlobFS').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobStorage to AzureBlobFS').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Excel_AzureBlobFS_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Excel_AzureBlobFS_Parquet.json
@@ -1,0 +1,273 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Excel_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "SheetName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SheetName"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Excel_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings"
+                        },
+                        "type": "ExcelSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobStorage to AzureBlobFS').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobStorage to AzureBlobFS').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Excel_AzureBlobStorage_DelimitedText.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Excel_AzureBlobStorage_DelimitedText.json
@@ -1,0 +1,282 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Excel_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "SheetName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SheetName"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Excel_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "formatSettings": {
+                              "fileExtension": ".txt",
+                              "quoteAllText": true,
+                              "type": "DelimitedTextWriteSettings"
+                           },
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "DelimitedTextSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings"
+                        },
+                        "type": "ExcelSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobStorage to AzureBlobStorage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobStorage to AzureBlobStorage').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Excel_AzureBlobStorage_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Excel_AzureBlobStorage_Parquet.json
@@ -1,0 +1,273 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Excel_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "SheetName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SheetName"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Excel_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings"
+                        },
+                        "type": "ExcelSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobStorage to AzureBlobStorage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobStorage to AzureBlobStorage').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Excel_AzureSqlTable_NA.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Excel_AzureSqlTable_NA.json
@@ -1,0 +1,390 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Excel_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "description": "Auto Creates Table Using a Schema File",
+                  "name": "If Auto Create Table",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Create Table",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_Create_Table_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Execute Create Table",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Mapping",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n  string(pipeline().parameters.TaskObject.TaskInstanceId), \n  '\",\"ExecutionUid\":\"', \n  string(pipeline().parameters.TaskObject.ExecutionUid), \n  '\",\"RunId\":\"', \n  string(pipeline().RunId), \n  '\",\"StorageAccountName\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.SystemServer), \n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Source.SchemaFileName), \n  '\",\"SourceType\":\"', \n  if(\n     contains(string(pipeline().parameters.TaskObject.Source.System.SystemServer),'.dfs.core.windows.net'),\n     'ADLS',\n     'Azure Blob'\n    ), \n  '\",\"TargetType\":\"', \n  string(pipeline().parameters.TaskObject.Target.Type), \n  '\",\"MetadataType\":\"Parquet\"}')\n)"
+                              },
+                              "functionName": "GetSourceTargetMapping",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           },
+                           "SheetName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.SheetName"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Excel_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy to SQL",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "disableMetricsCollection": false,
+                        "preCopyScript": {
+                           "type": "Expression",
+                           "value": "@{pipeline().parameters.TaskObject.Target.PreCopySQL}"
+                        },
+                        "tableOption": "autoCreate",
+                        "type": "AzureSqlSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings"
+                        },
+                        "type": "ExcelSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@if(and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable)),activity('AF Get Mapping').output.value, null)"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy to SQL').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy to SQL').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Execute AZ_SQL_Post-Copy",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "TaskObject": {
+                           "type": "Expression",
+                           "value": "@pipeline().parameters.TaskObject"
+                        }
+                     },
+                     "pipeline": {
+                        "referenceName": "[concat('GPL_AzureSqlTable_NA_Post_Copy_', parameters('integrationRuntimeShortName'))]",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-07-29T09:43:40Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Json_AzureSqlTable_NA.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Json_AzureSqlTable_NA.json
@@ -1,0 +1,385 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Json_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "description": "Auto Creates Table Using a Schema File",
+                  "name": "If Auto Create Table",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Create Table",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_Create_Table_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Execute Create Table",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Mapping",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n  string(pipeline().parameters.TaskObject.TaskInstanceId), \n  '\",\"ExecutionUid\":\"', \n  string(pipeline().parameters.TaskObject.ExecutionUid), \n  '\",\"RunId\":\"', \n  string(pipeline().RunId), \n  '\",\"StorageAccountName\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.SystemServer), \n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Source.SchemaFileName), \n  '\",\"SourceType\":\"', \n  if(\n     contains(string(pipeline().parameters.TaskObject.Source.System.SystemServer),'.dfs.core.windows.net'),\n     'ADLS',\n     'Azure Blob'\n    ), \n  '\",\"TargetType\":\"', \n  string(pipeline().parameters.TaskObject.Target.Type), \n  '\",\"MetadataType\":\"Parquet\"}')\n)"
+                              },
+                              "functionName": "GetSourceTargetMapping",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Json_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy to SQL",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "disableMetricsCollection": false,
+                        "preCopyScript": {
+                           "type": "Expression",
+                           "value": "@{pipeline().parameters.TaskObject.Target.PreCopySQL}"
+                        },
+                        "tableOption": "autoCreate",
+                        "type": "AzureSqlSink"
+                     },
+                     "source": {
+                        "formatSettings": {
+                           "type": "JsonReadSettings"
+                        },
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings"
+                        },
+                        "type": "JsonSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@if(and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable)),activity('AF Get Mapping').output.value, null)"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy to SQL').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy to SQL').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Execute AZ_SQL_Post-Copy",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "TaskObject": {
+                           "type": "Expression",
+                           "value": "@pipeline().parameters.TaskObject"
+                        }
+                     },
+                     "pipeline": {
+                        "referenceName": "[concat('GPL_AzureSqlTable_NA_Post_Copy_', parameters('integrationRuntimeShortName'))]",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-07-29T09:43:40Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Parquet_AzureBlobFS_DelimitedText.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Parquet_AzureBlobFS_DelimitedText.json
@@ -1,0 +1,274 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Parquet_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "formatSettings": {
+                              "fileExtension": ".txt",
+                              "quoteAllText": true,
+                              "type": "DelimitedTextWriteSettings"
+                           },
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "DelimitedTextSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings"
+                        },
+                        "type": "ParquetSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobStorage to AzureBlobFS').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobFS",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobFS Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobStorage to AzureBlobFS').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Parquet_AzureBlobStorage_DelimitedText.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Parquet_AzureBlobStorage_DelimitedText.json
@@ -1,0 +1,274 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Parquet_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Started",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.DataFileName"
+                           },
+                           "FirstRowAsHeader": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.FirstRowAsHeader"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.RelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_DelimitedText_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "copyBehavior": "PreserveHierarchy",
+                           "formatSettings": {
+                              "fileExtension": ".txt",
+                              "quoteAllText": true,
+                              "type": "DelimitedTextWriteSettings"
+                           },
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "DelimitedTextSink"
+                     },
+                     "source": {
+                        "storeSettings": {
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings"
+                        },
+                        "type": "ParquetSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy AzureBlobStorage to AzureBlobStorage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Started",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy Blob to Blob\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy AzureBlobStorage to AzureBlobStorage').output.filesWritten), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy AzureBlobStorage to AzureBlobStorage Succeed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-05T04:14:00Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Parquet_AzureSqlTable_NA.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureBlobStorage_Parquet_AzureSqlTable_NA.json
@@ -1,0 +1,394 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureBlobStorage_Parquet_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "description": "Auto Creates Table Using a Schema File",
+                  "name": "If Auto Create Table",
+                  "type": "IfCondition",
+                  "typeProperties": {
+                     "expression": {
+                        "type": "Expression",
+                        "value": "@and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable))"
+                     },
+                     "ifTrueActivities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Create Table",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_AzureSqlTable_NA_Create_Table_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        },
+                        {
+                           "dependsOn": [
+                              {
+                                 "activity": "Execute Create Table",
+                                 "dependencyConditions": [
+                                    "Succeeded"
+                                 ]
+                              }
+                           ],
+                           "linkedServiceName": {
+                              "referenceName": "SLS_AzureFunctionApp",
+                              "type": "LinkedServiceReference"
+                           },
+                           "name": "AF Get Mapping",
+                           "policy": {
+                              "retry": 0,
+                              "retryIntervalInSeconds": 30,
+                              "secureInput": false,
+                              "secureOutput": false,
+                              "timeout": "7.00:00:00"
+                           },
+                           "type": "AzureFunctionActivity",
+                           "typeProperties": {
+                              "body": {
+                                 "type": "Expression",
+                                 "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n  string(pipeline().parameters.TaskObject.TaskInstanceId), \n  '\",\"ExecutionUid\":\"', \n  string(pipeline().parameters.TaskObject.ExecutionUid), \n  '\",\"RunId\":\"', \n  string(pipeline().RunId), \n  '\",\"StorageAccountName\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.SystemServer), \n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Source.SchemaFileName), \n  '\",\"SourceType\":\"', \n  if(\n     contains(string(pipeline().parameters.TaskObject.Source.System.SystemServer),'.dfs.core.windows.net'),\n     'ADLS',\n     'Azure Blob'\n    ), \n  '\",\"TargetType\":\"', \n  string(pipeline().parameters.TaskObject.Target.Type), \n  '\",\"MetadataType\":\"Parquet\"}')\n)"
+                              },
+                              "functionName": "GetSourceTargetMapping",
+                              "method": "POST"
+                           },
+                           "userProperties": [ ]
+                        }
+                     ]
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.DataFileName"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy to SQL",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.StagingTableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "disableMetricsCollection": false,
+                        "preCopyScript": {
+                           "type": "Expression",
+                           "value": "@{pipeline().parameters.TaskObject.Target.PreCopySQL}"
+                        },
+                        "tableOption": "autoCreate",
+                        "type": "AzureSqlSink"
+                     },
+                     "source": {
+                        "formatSettings": {
+                           "type": "AzureBlobStorageReadSettings"
+                        },
+                        "storeSettings": {
+                           "enablePartitionDiscovery": false,
+                           "recursive": true,
+                           "type": "AzureBlobStorageReadSettings",
+                           "wildcardFileName": {
+                              "type": "Expression",
+                              "value": "@concat(\n    replace(\n        pipeline().parameters.TaskObject.Source.DataFileName,\n        '.parquet',\n        ''\n        ),\n    '*.parquet'\n)"
+                           },
+                           "wildcardFolderPath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.Instance.SourceRelativePath"
+                           }
+                        },
+                        "type": "ParquetSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@if(and(not(equals(coalesce(pipeline().parameters.TaskObject.Source.SchemaFileName,''),'')),bool(pipeline().parameters.TaskObject.Target.AutoCreateTable)),activity('AF Get Mapping').output.value, null)"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy to SQL').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy to SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy to SQL\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy to SQL').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Succeed",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Execute AZ_SQL_Post-Copy",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "TaskObject": {
+                           "type": "Expression",
+                           "value": "@pipeline().parameters.TaskObject"
+                        }
+                     },
+                     "pipeline": {
+                        "referenceName": "[concat('GPL_AzureSqlTable_NA_Post_Copy_', parameters('integrationRuntimeShortName'))]",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - ADLS to Azure SQL Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "If Auto Create Table",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Execute AZ_SQL_Post-Copy",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-07-29T09:43:40Z",
+            "parameters": {
+               "TaskObject": {
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureSqlTable_NA_AzureBlobFS_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureSqlTable_NA_AzureBlobFS_Parquet.json
@@ -1,0 +1,625 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Get Information Schema SQL",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TableSchema\":\"', string(pipeline().parameters.TaskObject.Source.TableSchema), '\",\"TableName\":\"', string(pipeline().parameters.TaskObject.Source.TableName),'\"}'))"
+                     },
+                     "functionName": "GetInformationSchemaSQL",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Get Information Schema SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Lookup Get SQL Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Lookup",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "firstRowOnly": false,
+                     "source": {
+                        "partitionOption": "None",
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@activity('AF Get Information Schema SQL').output.InformationSchemaSQL"
+                        },
+                        "type": "AzureSqlSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Lookup Get SQL Metadata",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "AF Log - Get Metadata Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Get Metadata\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Lookup Get SQL Metadata').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Lookup Get SQL Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Metadata and Get Mapping",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat('{\"TaskInstanceId\":\"',\n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Target.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n  '\",\"SourceType\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Type), \n  '\",\"TargetType\":\"', \n  if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'), \n  '\",\"Data\":',\n  string(activity('Lookup Get SQL Metadata').output),\n  ',\"MetadataType\":\"SQL\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Persist Metadata and Get Mapping",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Switch Load Type",
+                  "type": "Switch",
+                  "typeProperties": {
+                     "cases": [
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Execute Full_Load Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": "1",
+                                       "Item": "1",
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Full"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup New Watermark",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Watermark Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": "1",
+                                       "Item": "1",
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "NewWaterMark": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark').output.firstRow.newWatermark"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup New Watermark",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "Schema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "Table": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "AzureSqlSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Watermark"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup Chunk",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Full Load Chunk Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup Chunk').output.firstRow.batchcount"
+                                       },
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_Full_Load_Chunk_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup Chunk",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "Schema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "Table": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "AzureSqlSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Full_Chunk"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup New Watermark and Chunk",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Watermark Chunk Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark and Chunk').output.firstRow.batchcount"
+                                       },
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "NewWatermark": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark and Chunk').output.firstRow.newWatermark"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobFS_Parquet_Watermark_Chunk_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup New Watermark and Chunk",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "Schema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "Table": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "AzureSqlSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Watermark_Chunk"
+                        }
+                     ],
+                     "on": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.Source.IncrementalType"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Get Information Schema SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "AF Log - Get Metadata Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "AF Persist Metadata and Get Mapping",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "Switch Load Type",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Switch Load Type",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-04T12:40:45Z",
+            "parameters": {
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/arm/GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet.json
@@ -1,0 +1,625 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Get Information Schema SQL",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TableSchema\":\"', string(pipeline().parameters.TaskObject.Source.TableSchema), '\",\"TableName\":\"', string(pipeline().parameters.TaskObject.Source.TableName),'\"}'))"
+                     },
+                     "functionName": "GetInformationSchemaSQL",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Get Information Schema SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Lookup Get SQL Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Lookup",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "Schema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "Table": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "firstRowOnly": false,
+                     "source": {
+                        "partitionOption": "None",
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@activity('AF Get Information Schema SQL').output.InformationSchemaSQL"
+                        },
+                        "type": "AzureSqlSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Lookup Get SQL Metadata",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "AF Log - Get Metadata Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Get Metadata\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Lookup Get SQL Metadata').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Lookup Get SQL Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Metadata and Get Mapping",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat('{\"TaskInstanceId\":\"',\n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Target.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n  '\",\"SourceType\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Type), \n  '\",\"TargetType\":\"', \n  if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'), \n  '\",\"Data\":',\n  string(activity('Lookup Get SQL Metadata').output),\n  ',\"MetadataType\":\"SQL\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Persist Metadata and Get Mapping",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Switch Load Type",
+                  "type": "Switch",
+                  "typeProperties": {
+                     "cases": [
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Execute Full_Load Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": "1",
+                                       "Item": "1",
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Full"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup New Watermark",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Watermark Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": "1",
+                                       "Item": "1",
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "NewWaterMark": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark').output.firstRow.newWatermark"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup New Watermark",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "Schema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "Table": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "AzureSqlSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Watermark"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup Chunk",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Full Load Chunk Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup Chunk').output.firstRow.batchcount"
+                                       },
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_Full_Load_Chunk_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup Chunk",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "Schema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "Table": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "AzureSqlSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Full_Chunk"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup New Watermark and Chunk",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Watermark Chunk Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark and Chunk').output.firstRow.batchcount"
+                                       },
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "NewWatermark": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark and Chunk').output.firstRow.newWatermark"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_AzureSqlTable_NA_AzureBlobStorage_Parquet_Watermark_Chunk_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup New Watermark and Chunk",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "Schema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "Table": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_AzureSqlTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "AzureSqlSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Watermark_Chunk"
+                        }
+                     ],
+                     "on": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.Source.IncrementalType"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Get Information Schema SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "AF Log - Get Metadata Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "AF Persist Metadata and Get Mapping",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "Switch Load Type",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Switch Load Type",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-04T12:40:45Z",
+            "parameters": {
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/main.tf
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_azure/main.tf
@@ -1,9 +1,9 @@
-resource "azurerm_resource_group_template_deployment" "azure_pipelines" {
+resource "azurerm_resource_group_template_deployment" "azure_pipelines_level_0" {
   for_each            = {
-    for pipeline in fileset(path.module, "arm/GPL_Azure*.json"):  
+    for pipeline in fileset(path.module, "arm/GPL0_Azure*.json"):  
     pipeline => pipeline 
   }
-  name                = "${replace(replace(each.value, ".json", ""), "arm/", "")}_${var.integration_runtime_short_name}_${var.name_suffix}"
+  name                = substr(sha256("${replace(replace(each.value, ".json", ""), "arm/", "")}_${var.integration_runtime_short_name}_${var.name_suffix}"), 0,30)
   resource_group_name = var.resource_group_name
   deployment_mode     = "Incremental"
   parameters_content = jsonencode({
@@ -21,4 +21,61 @@ resource "azurerm_resource_group_template_deployment" "azure_pipelines" {
     },
   })
   template_content = file("${path.module}/${each.value}")
+}
+
+resource "azurerm_resource_group_template_deployment" "azure_pipelines_level_1" {
+  for_each            = {
+    for pipeline in fileset(path.module, "arm/GPL1_Azure*.json"):  
+    pipeline => pipeline 
+  }
+  name                = substr(sha256("${replace(replace(each.value, ".json", ""), "arm/", "")}_${var.integration_runtime_short_name}_${var.name_suffix}"), 0,30)
+  resource_group_name = var.resource_group_name
+  deployment_mode     = "Incremental"
+  parameters_content = jsonencode({
+    "dataFactoryName" = {
+      value = var.data_factory_name
+    },    
+    "integrationRuntimeName" = {
+      value = var.integration_runtime_name
+    },
+    "integrationRuntimeShortName" = {
+      value = var.integration_runtime_short_name
+    },
+    "sharedKeyVaultUri" = {
+      value = var.shared_keyvault_uri
+    },
+  })
+  template_content = file("${path.module}/${each.value}")
+  depends_on = [
+    azurerm_resource_group_template_deployment.azure_pipelines_level_0
+  ]  
+}
+
+resource "azurerm_resource_group_template_deployment" "azure_pipelines" {
+  for_each            = {
+    for pipeline in fileset(path.module, "arm/GPL_Azure*.json"):  
+    pipeline => pipeline 
+  }
+  name                = substr(sha256("${replace(replace(each.value, ".json", ""), "arm/", "")}_${var.integration_runtime_short_name}_${var.name_suffix}"), 0,30)
+  resource_group_name = var.resource_group_name
+  deployment_mode     = "Incremental"
+  parameters_content = jsonencode({
+    "dataFactoryName" = {
+      value = var.data_factory_name
+    },    
+    "integrationRuntimeName" = {
+      value = var.integration_runtime_name
+    },
+    "integrationRuntimeShortName" = {
+      value = var.integration_runtime_short_name
+    },
+    "sharedKeyVaultUri" = {
+      value = var.shared_keyvault_uri
+    },
+  })
+  template_content = file("${path.module}/${each.value}")
+  depends_on = [
+    azurerm_resource_group_template_deployment.azure_pipelines_level_0,
+    azurerm_resource_group_template_deployment.azure_pipelines_level_1
+  ]
 }

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_common/arm/SPL_AzureFunction.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_common/arm/SPL_AzureFunction.json
@@ -1,0 +1,121 @@
+{
+	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+	"contentVersion": "1.0.0.0",
+	"parameters": {
+		"dataFactoryName": {
+			"type": "String",
+			"metadata": "The name of the data factory"
+		},
+		"functionLinkedServiceName": {
+			"type": "String",
+			"metadata": "The name of the azure function linked service that this dataset uses"
+		}	
+	},	
+	"resources": [
+		{
+			"apiVersion": "2018-06-01",
+			"name": "[concat(parameters('dataFactoryName'), '/SPL_AzureFunction')]",
+			"type": "Microsoft.DataFactory/factories/pipelines",
+			"properties": {
+				"activities": [
+					{
+						"name": "Switch Method",
+						"type": "Switch",
+						"dependsOn": [],
+						"userProperties": [],
+						"typeProperties": {
+							"on": {
+								"value": "@pipeline().parameters.Method",
+								"type": "Expression"
+							},
+							"cases": [
+								{
+									"value": "Put",
+									"activities": [
+										{
+											"name": "Azure Function Generic Put",
+											"type": "AzureFunctionActivity",
+											"dependsOn": [],
+											"policy": {
+												"timeout": "7.00:00:00",
+												"retry": 0,
+												"retryIntervalInSeconds": 30,
+												"secureOutput": false,
+												"secureInput": false
+											},
+											"userProperties": [],
+											"typeProperties": {
+												"functionName": {
+													"value": "@pipeline().parameters.FunctionName",
+													"type": "Expression"
+												},
+												"method": "PUT",
+												"body": {
+													"value": "@pipeline().parameters.Body",
+													"type": "Expression"
+												}
+											},
+											"linkedServiceName": {
+												"referenceName": "[parameters('functionLinkedServiceName')]",
+												"type": "LinkedServiceReference"
+											}
+										}
+									]
+								},
+								{
+									"value": "Post",
+									"activities": [
+										{
+											"name": "Azure Function Generic Post",
+											"type": "AzureFunctionActivity",
+											"dependsOn": [],
+											"policy": {
+												"timeout": "7.00:00:00",
+												"retry": 0,
+												"retryIntervalInSeconds": 30,
+												"secureOutput": false,
+												"secureInput": false
+											},
+											"userProperties": [],
+											"typeProperties": {
+												"functionName": {
+													"value": "@pipeline().parameters.FunctionName",
+													"type": "Expression"
+												},
+												"method": "POST",
+												"body": {
+													"value": "@pipeline().parameters.Body",
+													"type": "Expression"
+												}
+											},
+											"linkedServiceName": {
+												"referenceName": "[parameters('functionLinkedServiceName')]",
+												"type": "LinkedServiceReference"
+											}
+										}
+									]
+								}
+							]
+						}
+					}
+				],
+				"parameters": {
+					"Body": {
+						"type": "String"
+					},
+					"FunctionName": {
+						"type": "String"
+					},
+					"Method": {
+						"type": "String"
+					}
+				},
+				"folder": {
+					"name": "ADS Go Fast/Common"
+				},
+				"annotations": [],
+				"lastPublishTime": "2020-07-14T10:58:30Z"
+			}
+		}
+	]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_common/main.tf
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_common/main.tf
@@ -10,5 +10,5 @@ resource "azurerm_resource_group_template_deployment" "pipeline_generic_function
       value = var.linkedservice_azure_function_name
     }
   })
-  template_content = file("${path.module}/arm/GPL_AzureFunction_Common.json")
+  template_content = file("${path.module}/arm/SPL_AzureFunction.json")
 }

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL0_SqlServerTable_NA_AzureBlobFS_Parquet_Full_Load.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL0_SqlServerTable_NA_AzureBlobFS_Parquet_Full_Load.json
@@ -1,0 +1,390 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_SqlServerTable_NA_AzureBlobFS_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - Copy Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Set SQLStatement",
+                  "type": "SetVariable",
+                  "typeProperties": {
+                     "value": {
+                        "type": "Expression",
+                        "value": "@replace(replace(pipeline().parameters.TaskObject.Source.SQLStatement,'<batchcount>',string(pipeline().parameters.BatchCount)),'<item>',string(pipeline().parameters.Item))"
+                     },
+                     "variableName": "SQLStatement"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Set SQLStatement",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "KeyVaultBaseUrl": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                           },
+                           "PasswordSecret": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "TableName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           },
+                           "TableSchema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "UserName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy SQL to Storage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@variables('SQLStatement')"
+                        },
+                        "type": "SqlServerSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.Mapping"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy SQL to Storage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Get Parquet Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', \n string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer), \n '\",\"StorageAccountContainer\":\"', \n string(pipeline().parameters.TaskObject.Target.System.Container), \n '\",\"RelativePath\":\"', \n string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n '\",\"SchemaFileName\":\"', \n string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n '\",\"SourceType\":\"', \n string(pipeline().parameters.TaskObject.Source.System.Type), \n '\",\"TargetType\":\"', \n if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'),  \n '\",\"Data\":',\n string(activity('Get Parquet Metadata').output),\n ',\"MetadataType\":\"Parquet\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Get Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "GetMetadata",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "fieldList": [
+                        "structure"
+                     ],
+                     "storeSettings": {
+                        "recursive": true,
+                        "type": "AzureBlobFSReadSettings"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - Copy Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy SQL to Storage').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Item": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL0_SqlServerTable_NA_AzureBlobFS_Parquet_Watermark.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL0_SqlServerTable_NA_AzureBlobFS_Parquet_Watermark.json
@@ -1,0 +1,393 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_SqlServerTable_NA_AzureBlobFS_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - Copy Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Set SQLStatement",
+                  "type": "SetVariable",
+                  "typeProperties": {
+                     "value": {
+                        "type": "Expression",
+                        "value": "@replace(\n replace(\n  replace(\n   pipeline().parameters.TaskObject.Source.SQLStatement,\n   '<batchcount>',\n   string(pipeline().parameters.BatchCount)\n   ),\n '<item>',string(pipeline().parameters.Item)),\n '<newWatermark>',string(pipeline().parameters.NewWaterMark)\n)"
+                     },
+                     "variableName": "SQLStatement"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Set SQLStatement",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "KeyVaultBaseUrl": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                           },
+                           "PasswordSecret": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "TableName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           },
+                           "TableSchema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "UserName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy SQL to Storage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "type": "AzureBlobFSWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@variables('SQLStatement')"
+                        },
+                        "type": "SqlServerSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.Mapping"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy SQL to Storage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Get Parquet Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat(\n '{\"TaskInstanceId\":\"', \n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', \n string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer), \n '\",\"StorageAccountContainer\":\"', \n string(pipeline().parameters.TaskObject.Target.System.Container), \n '\",\"RelativePath\":\"', \n string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n '\",\"SchemaFileName\":\"', \n string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n '\",\"SourceType\":\"', \n string(pipeline().parameters.TaskObject.Source.System.Type), \n '\",\"TargetType\":\"', \n if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'), \n '\",\"Data\":',\n string(activity('Get Parquet Metadata').output),\n ',\"MetadataType\":\"Parquet\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Get Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "GetMetadata",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "fieldList": [
+                        "structure"
+                     ],
+                     "storeSettings": {
+                        "recursive": true,
+                        "type": "AzureBlobFSReadSettings"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - Copy Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy SQL to Storage').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Item": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "NewWaterMark": {
+                  "type": "string"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL0_SqlServerTable_NA_AzureBlobStorage_Parquet_Full_Load.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL0_SqlServerTable_NA_AzureBlobStorage_Parquet_Full_Load.json
@@ -1,0 +1,390 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - Copy Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Set SQLStatement",
+                  "type": "SetVariable",
+                  "typeProperties": {
+                     "value": {
+                        "type": "Expression",
+                        "value": "@replace(replace(pipeline().parameters.TaskObject.Source.SQLStatement,'<batchcount>',string(pipeline().parameters.BatchCount)),'<item>',string(pipeline().parameters.Item))"
+                     },
+                     "variableName": "SQLStatement"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Set SQLStatement",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "KeyVaultBaseUrl": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                           },
+                           "PasswordSecret": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "TableName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           },
+                           "TableSchema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "UserName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy SQL to Storage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@variables('SQLStatement')"
+                        },
+                        "type": "SqlServerSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.Mapping"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy SQL to Storage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Get Parquet Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat('{\"TaskInstanceId\":\"', \n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', \n string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer), \n '\",\"StorageAccountContainer\":\"', \n string(pipeline().parameters.TaskObject.Target.System.Container), \n '\",\"RelativePath\":\"', \n string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n '\",\"SchemaFileName\":\"', \n string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n '\",\"SourceType\":\"', \n string(pipeline().parameters.TaskObject.Source.System.Type), \n '\",\"TargetType\":\"', \n if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'),  \n '\",\"Data\":',\n string(activity('Get Parquet Metadata').output),\n ',\"MetadataType\":\"Parquet\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Get Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "GetMetadata",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "fieldList": [
+                        "structure"
+                     ],
+                     "storeSettings": {
+                        "recursive": true,
+                        "type": "AzureBlobFSReadSettings"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - Copy Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy SQL to Storage').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Item": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL0_SqlServerTable_NA_AzureBlobStorage_Parquet_Watermark.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL0_SqlServerTable_NA_AzureBlobStorage_Parquet_Watermark.json
@@ -1,0 +1,393 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Pipeline AF Log - Copy Start",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Set SQLStatement",
+                  "type": "SetVariable",
+                  "typeProperties": {
+                     "value": {
+                        "type": "Expression",
+                        "value": "@replace(\n replace(\n  replace(\n   pipeline().parameters.TaskObject.Source.SQLStatement,\n   '<batchcount>',\n   string(pipeline().parameters.BatchCount)\n   ),\n '<item>',string(pipeline().parameters.Item)),\n '<newWatermark>',string(pipeline().parameters.NewWaterMark)\n)"
+                     },
+                     "variableName": "SQLStatement"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Set SQLStatement",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "inputs": [
+                     {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "KeyVaultBaseUrl": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                           },
+                           "PasswordSecret": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "TableName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           },
+                           "TableSchema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "UserName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "name": "Copy SQL to Storage",
+                  "outputs": [
+                     {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     }
+                  ],
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Copy",
+                  "typeProperties": {
+                     "enableStaging": false,
+                     "parallelCopies": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.DegreeOfCopyParallelism"
+                     },
+                     "sink": {
+                        "storeSettings": {
+                           "type": "AzureBlobStorageWriteSettings"
+                        },
+                        "type": "ParquetSink"
+                     },
+                     "source": {
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@variables('SQLStatement')"
+                        },
+                        "type": "SqlServerSource"
+                     },
+                     "translator": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.Mapping"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Copy SQL to Storage').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Get Parquet Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat(\n '{\"TaskInstanceId\":\"', \n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', \n string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer), \n '\",\"StorageAccountContainer\":\"', \n string(pipeline().parameters.TaskObject.Target.System.Container), \n '\",\"RelativePath\":\"', \n string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n '\",\"SchemaFileName\":\"', \n string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n '\",\"SourceType\":\"', \n string(pipeline().parameters.TaskObject.Source.System.Type), \n '\",\"TargetType\":\"', \n if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'), \n '\",\"Data\":',\n string(activity('Get Parquet Metadata').output),\n ',\"MetadataType\":\"Parquet\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Get Parquet Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "GetMetadata",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "FileName": {
+                              "type": "Expression",
+                              "value": "@if(equals(pipeline().parameters.TaskObject.Source.ChunkSize,0),\n    pipeline().parameters.TaskObject.Target.DataFileName,\n    replace(\n        pipeline().parameters.TaskObject.Target.DataFileName,\n        '.parquet',\n        concat('.chunk_', string(pipeline().parameters.Item),'.parquet')\n    )\n)"
+                           },
+                           "RelativePath": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath"
+                           },
+                           "StorageAccountContainerName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.Container"
+                           },
+                           "StorageAccountEndpoint": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Target.System.SystemServer"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "fieldList": [
+                        "structure"
+                     ],
+                     "storeSettings": {
+                        "recursive": true,
+                        "type": "AzureBlobFSReadSettings"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "Pipeline AF Log - Copy Start",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":3,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"Status\":\"Started\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Copy SQL to Storage",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Copy Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Copy SQL to Storage\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"RowsInserted\":\"', string(activity('Copy SQL to Storage').output.rowsCopied), '\",\"Comment\":\"\",\"Status\":\"Complete\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Item": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "NewWaterMark": {
+                  "type": "string"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL1_SqlServerTable_NA_AzureBlobFS_Parquet_Full_Load_Chunk.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL1_SqlServerTable_NA_AzureBlobFS_Parquet_Full_Load_Chunk.json
@@ -1,0 +1,143 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_SqlServerTable_NA_AzureBlobFS_Parquet_Full_Load_Chunk_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "ForEach Chunk",
+                  "type": "ForEach",
+                  "typeProperties": {
+                     "activities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Full Load",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "BatchCount": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.BatchCount"
+                                 },
+                                 "Item": {
+                                    "type": "Expression",
+                                    "value": "@item()"
+                                 },
+                                 "Mapping": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.Mapping"
+                                 },
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobFS_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        }
+                     ],
+                     "isSequential": true,
+                     "items": {
+                        "type": "Expression",
+                        "value": "@range(1, pipeline().parameters.BatchCount)"
+                     }
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "SH-AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL1_SqlServerTable_NA_AzureBlobFS_Parquet_Watermark_Chunk.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL1_SqlServerTable_NA_AzureBlobFS_Parquet_Watermark_Chunk.json
@@ -1,0 +1,178 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_SqlServerTable_NA_AzureBlobFS_Parquet_Watermark_Chunk_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "ForEach Chunk",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "AF Set New Watermark",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TaskMasterId\":\"', string(pipeline().parameters.TaskObject.TaskMasterId),'\",\"TaskMasterWaterMarkColumnType\":\"', string(pipeline().parameters.TaskObject.Source.IncrementalColumnType),'\",\"WaterMarkValue\":\"', string(pipeline().parameters.NewWatermark), '\"}'))"
+                        },
+                        "FunctionName": "WaterMark",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "ForEach Chunk",
+                  "type": "ForEach",
+                  "typeProperties": {
+                     "activities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Watermark",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "BatchCount": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.BatchCount"
+                                 },
+                                 "Item": {
+                                    "type": "Expression",
+                                    "value": "@item()"
+                                 },
+                                 "Mapping": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.Mapping"
+                                 },
+                                 "NewWaterMark": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.NewWatermark"
+                                 },
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobFS_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        }
+                     ],
+                     "isSequential": true,
+                     "items": {
+                        "type": "Expression",
+                        "value": "@range(1, pipeline().parameters.BatchCount)"
+                     }
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "NewWatermark": {
+                  "type": "string"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL1_SqlServerTable_NA_AzureBlobStorage_Parquet_Full_Load_Chunk.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL1_SqlServerTable_NA_AzureBlobStorage_Parquet_Full_Load_Chunk.json
@@ -1,0 +1,143 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_Full_Load_Chunk_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "name": "ForEach Chunk",
+                  "type": "ForEach",
+                  "typeProperties": {
+                     "activities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Full Load",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "BatchCount": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.BatchCount"
+                                 },
+                                 "Item": {
+                                    "type": "Expression",
+                                    "value": "@item()"
+                                 },
+                                 "Mapping": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.Mapping"
+                                 },
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        }
+                     ],
+                     "isSequential": true,
+                     "items": {
+                        "type": "Expression",
+                        "value": "@range(1, pipeline().parameters.BatchCount)"
+                     }
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "SH-AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL1_SqlServerTable_NA_AzureBlobStorage_Parquet_Watermark_Chunk.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL1_SqlServerTable_NA_AzureBlobStorage_Parquet_Watermark_Chunk.json
@@ -1,0 +1,178 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_Watermark_Chunk_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "ForEach Chunk",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "AF Set New Watermark",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TaskMasterId\":\"', string(pipeline().parameters.TaskObject.TaskMasterId),'\",\"TaskMasterWaterMarkColumnType\":\"', string(pipeline().parameters.TaskObject.Source.IncrementalColumnType),'\",\"WaterMarkValue\":\"', string(pipeline().parameters.NewWatermark), '\"}'))"
+                        },
+                        "FunctionName": "WaterMark",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [ ],
+                  "name": "ForEach Chunk",
+                  "type": "ForEach",
+                  "typeProperties": {
+                     "activities": [
+                        {
+                           "dependsOn": [ ],
+                           "name": "Execute Watermark",
+                           "type": "ExecutePipeline",
+                           "typeProperties": {
+                              "parameters": {
+                                 "BatchCount": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.BatchCount"
+                                 },
+                                 "Item": {
+                                    "type": "Expression",
+                                    "value": "@item()"
+                                 },
+                                 "Mapping": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.Mapping"
+                                 },
+                                 "NewWaterMark": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.NewWatermark"
+                                 },
+                                 "TaskObject": {
+                                    "type": "Expression",
+                                    "value": "@pipeline().parameters.TaskObject"
+                                 }
+                              },
+                              "pipeline": {
+                                 "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+                                 "type": "PipelineReference"
+                              },
+                              "waitOnCompletion": true
+                           },
+                           "userProperties": [ ]
+                        }
+                     ],
+                     "isSequential": true,
+                     "items": {
+                        "type": "Expression",
+                        "value": "@range(1, pipeline().parameters.BatchCount)"
+                     }
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'), '/Components')]"
+            },
+            "parameters": {
+               "BatchCount": {
+                  "type": "int"
+               },
+               "Mapping": {
+                  "type": "object"
+               },
+               "NewWatermark": {
+                  "type": "string"
+               },
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL_SqlServerTable_NA_AzureBlobFS_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL_SqlServerTable_NA_AzureBlobFS_Parquet.json
@@ -1,0 +1,673 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_SqlServerTable_NA_AzureBlobFS_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Get Information Schema SQL",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TableSchema\":\"', string(pipeline().parameters.TaskObject.Source.TableSchema), '\",\"TableName\":\"', string(pipeline().parameters.TaskObject.Source.TableName),'\"}'))"
+                     },
+                     "functionName": "GetInformationSchemaSQL",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Get Information Schema SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Lookup Get SQL Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Lookup",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "KeyVaultBaseUrl": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                           },
+                           "PasswordSecret": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "TableName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           },
+                           "TableSchema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "UserName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "firstRowOnly": false,
+                     "source": {
+                        "partitionOption": "None",
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@activity('AF Get Information Schema SQL').output.InformationSchemaSQL"
+                        },
+                        "type": "SqlServerSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Lookup Get SQL Metadata",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "AF Log - Get Metadata Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Get Metadata\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Lookup Get SQL Metadata').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Lookup Get SQL Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Metadata and Get Mapping",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat('{\"TaskInstanceId\":\"',\n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Target.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n  '\",\"SourceType\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Type), \n  '\",\"TargetType\":\"', \n  if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'), \n  '\",\"Data\":',\n  string(activity('Lookup Get SQL Metadata').output),\n  ',\"MetadataType\":\"SQL\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Persist Metadata and Get Mapping",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Switch Load Type",
+                  "type": "Switch",
+                  "typeProperties": {
+                     "cases": [
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Execute Full_Load Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": "1",
+                                       "Item": "1",
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobFS_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Full"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup New Watermark",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Watermark Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": "1",
+                                       "Item": "1",
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "NewWaterMark": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark').output.firstRow.newWatermark"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobFS_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup New Watermark",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "KeyVaultBaseUrl": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                                          },
+                                          "PasswordSecret": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "TableName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          },
+                                          "TableSchema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "UserName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "SqlServerSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Watermark"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup Chunk",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Full Load Chunk Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup Chunk').output.firstRow.batchcount"
+                                       },
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobFS_Parquet_Full_Load_Chunk_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup Chunk",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "KeyVaultBaseUrl": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                                          },
+                                          "PasswordSecret": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "TableName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          },
+                                          "TableSchema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "UserName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "SqlServerSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Full_Chunk"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup New Watermark and Chunk",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Watermark Chunk Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark and Chunk').output.firstRow.batchcount"
+                                       },
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "NewWatermark": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark and Chunk').output.firstRow.newWatermark"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobFS_Parquet_Watermark_Chunk_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup New Watermark and Chunk",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "KeyVaultBaseUrl": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                                          },
+                                          "PasswordSecret": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "TableName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          },
+                                          "TableSchema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "UserName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "SqlServerSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Watermark_Chunk"
+                        }
+                     ],
+                     "on": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.Source.IncrementalType"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Get Information Schema SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "AF Log - Get Metadata Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "AF Persist Metadata and Get Mapping",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "Switch Load Type",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Switch Load Type",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-04T12:40:45Z",
+            "parameters": {
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL_SqlServerTable_NA_AzureBlobStorage_Parquet.json
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/arm/GPL_SqlServerTable_NA_AzureBlobStorage_Parquet.json
@@ -1,0 +1,673 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "dataFactoryName": {
+         "metadata": "The name of the data factory",
+         "type": "String"
+      },
+      "integrationRuntimeName": {
+         "metadata": "The name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "integrationRuntimeShortName": {
+         "metadata": "The short name of the integration runtime this pipeline uses",
+         "type": "String"
+      },
+      "sharedKeyVaultUri": {
+         "metadata": "The uri of the shared KeyVault",
+         "type": "String"
+      }
+   },
+   "resources": [
+      {
+         "apiVersion": "2018-06-01",
+         "name": "[concat(parameters('dataFactoryName'), '/','GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_', parameters('integrationRuntimeShortName'))]",
+         "properties": {
+            "activities": [
+               {
+                  "dependsOn": [ ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Get Information Schema SQL",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"TableSchema\":\"', string(pipeline().parameters.TaskObject.Source.TableSchema), '\",\"TableName\":\"', string(pipeline().parameters.TaskObject.Source.TableName),'\"}'))"
+                     },
+                     "functionName": "GetInformationSchemaSQL",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Get Information Schema SQL",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Lookup Get SQL Metadata",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "Lookup",
+                  "typeProperties": {
+                     "dataset": {
+                        "parameters": {
+                           "Database": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                           },
+                           "KeyVaultBaseUrl": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                           },
+                           "PasswordSecret": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                           },
+                           "Server": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                           },
+                           "TableName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                           },
+                           "TableSchema": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                           },
+                           "UserName": {
+                              "type": "Expression",
+                              "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                           }
+                        },
+                        "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                        "type": "DatasetReference"
+                     },
+                     "firstRowOnly": false,
+                     "source": {
+                        "partitionOption": "None",
+                        "queryTimeout": "02:00:00",
+                        "sqlReaderQuery": {
+                           "type": "Expression",
+                           "value": "@activity('AF Get Information Schema SQL').output.InformationSchemaSQL"
+                        },
+                        "type": "SqlServerSource"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Lookup Get SQL Metadata",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "AF Log - Get Metadata Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Get Metadata\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"', string(activity('Lookup Get SQL Metadata').error.message), '\",\"Status\":\"Failed\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": false
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Lookup Get SQL Metadata",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "linkedServiceName": {
+                     "referenceName": "SLS_AzureFunctionApp",
+                     "type": "LinkedServiceReference"
+                  },
+                  "name": "AF Persist Metadata and Get Mapping",
+                  "policy": {
+                     "retry": 0,
+                     "retryIntervalInSeconds": 30,
+                     "secureInput": false,
+                     "secureOutput": false,
+                     "timeout": "7.00:00:00"
+                  },
+                  "type": "AzureFunctionActivity",
+                  "typeProperties": {
+                     "body": {
+                        "type": "Expression",
+                        "value": "@json(\n concat('{\"TaskInstanceId\":\"',\n string(pipeline().parameters.TaskObject.TaskInstanceId), \n '\",\"ExecutionUid\":\"', \n string(pipeline().parameters.TaskObject.ExecutionUid), \n '\",\"RunId\":\"', string(pipeline().RunId), \n '\",\"StorageAccountName\":\"', \n string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n  '\",\"StorageAccountContainer\":\"', \n  string(pipeline().parameters.TaskObject.Target.System.Container), \n  '\",\"RelativePath\":\"', \n  string(pipeline().parameters.TaskObject.Target.Instance.TargetRelativePath), \n  '\",\"SchemaFileName\":\"', \n  string(pipeline().parameters.TaskObject.Target.SchemaFileName), \n  '\",\"SourceType\":\"', \n  string(pipeline().parameters.TaskObject.Source.System.Type), \n  '\",\"TargetType\":\"', \n  if(\n    contains(\n    string(pipeline().parameters.TaskObject.Target.System.SystemServer),\n    '.dfs.core.windows.net'\n    ),\n   'ADLS',\n   'Azure Blob'), \n  '\",\"Data\":',\n  string(activity('Lookup Get SQL Metadata').output),\n  ',\"MetadataType\":\"SQL\"}')\n)"
+                     },
+                     "functionName": "TaskExecutionSchemaFile",
+                     "method": "POST"
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Persist Metadata and Get Mapping",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Switch Load Type",
+                  "type": "Switch",
+                  "typeProperties": {
+                     "cases": [
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Execute Full_Load Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": "1",
+                                       "Item": "1",
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_Full_Load_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Full"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup New Watermark",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Watermark Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": "1",
+                                       "Item": "1",
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "NewWaterMark": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark').output.firstRow.newWatermark"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_Watermark_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup New Watermark",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "KeyVaultBaseUrl": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                                          },
+                                          "PasswordSecret": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "TableName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          },
+                                          "TableSchema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "UserName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "SqlServerSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Watermark"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup Chunk",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Full Load Chunk Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup Chunk').output.firstRow.batchcount"
+                                       },
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_Full_Load_Chunk_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup Chunk",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "KeyVaultBaseUrl": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                                          },
+                                          "PasswordSecret": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "TableName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          },
+                                          "TableSchema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "UserName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "SqlServerSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Full_Chunk"
+                        },
+                        {
+                           "activities": [
+                              {
+                                 "dependsOn": [
+                                    {
+                                       "activity": "Lookup New Watermark and Chunk",
+                                       "dependencyConditions": [
+                                          "Succeeded"
+                                       ]
+                                    }
+                                 ],
+                                 "name": "Execute Watermark Chunk Pipeline",
+                                 "type": "ExecutePipeline",
+                                 "typeProperties": {
+                                    "parameters": {
+                                       "BatchCount": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark and Chunk').output.firstRow.batchcount"
+                                       },
+                                       "Mapping": {
+                                          "type": "Expression",
+                                          "value": "@activity('AF Persist Metadata and Get Mapping').output.value"
+                                       },
+                                       "NewWatermark": {
+                                          "type": "Expression",
+                                          "value": "@activity('Lookup New Watermark and Chunk').output.firstRow.newWatermark"
+                                       },
+                                       "TaskObject": {
+                                          "type": "Expression",
+                                          "value": "@pipeline().parameters.TaskObject"
+                                       }
+                                    },
+                                    "pipeline": {
+                                       "referenceName": "[concat('GPL_SqlServerTable_NA_AzureBlobStorage_Parquet_Watermark_Chunk_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "PipelineReference"
+                                    },
+                                    "waitOnCompletion": true
+                                 },
+                                 "userProperties": [ ]
+                              },
+                              {
+                                 "dependsOn": [ ],
+                                 "name": "Lookup New Watermark and Chunk",
+                                 "policy": {
+                                    "retry": 0,
+                                    "retryIntervalInSeconds": 30,
+                                    "secureInput": false,
+                                    "secureOutput": false,
+                                    "timeout": "0.00:30:00"
+                                 },
+                                 "type": "Lookup",
+                                 "typeProperties": {
+                                    "dataset": {
+                                       "parameters": {
+                                          "Database": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Database"
+                                          },
+                                          "KeyVaultBaseUrl": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.KeyVaultBaseUrl"
+                                          },
+                                          "PasswordSecret": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.PasswordKeyVaultSecretName"
+                                          },
+                                          "Server": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.SystemServer"
+                                          },
+                                          "TableName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableName"
+                                          },
+                                          "TableSchema": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.TableSchema"
+                                          },
+                                          "UserName": {
+                                             "type": "Expression",
+                                             "value": "@pipeline().parameters.TaskObject.Source.System.Username"
+                                          }
+                                       },
+                                       "referenceName": "[concat('GDS_SqlServerTable_NA_', parameters('integrationRuntimeShortName'))]",
+                                       "type": "DatasetReference"
+                                    },
+                                    "firstRowOnly": true,
+                                    "source": {
+                                       "partitionOption": "None",
+                                       "queryTimeout": "02:00:00",
+                                       "sqlReaderQuery": {
+                                          "type": "Expression",
+                                          "value": "@{pipeline().parameters.TaskObject.Source.IncrementalSQLStatement}"
+                                       },
+                                       "type": "SqlServerSource"
+                                    }
+                                 },
+                                 "userProperties": [ ]
+                              }
+                           ],
+                           "value": "Watermark_Chunk"
+                        }
+                     ],
+                     "on": {
+                        "type": "Expression",
+                        "value": "@pipeline().parameters.TaskObject.Source.IncrementalType"
+                     }
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "AF Get Information Schema SQL",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "AF Log - Get Metadata Failed",
+                        "dependencyConditions": [
+                           "Completed"
+                        ]
+                     },
+                     {
+                        "activity": "AF Persist Metadata and Get Mapping",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     },
+                     {
+                        "activity": "Switch Load Type",
+                        "dependencyConditions": [
+                           "Failed"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Failed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(\r\n    concat('{\"TaskInstanceId\":\"', \r\n        string(pipeline().parameters.TaskObject.TaskInstanceId), \r\n        '\",\"ExecutionUid\":\"',\r\n         string(pipeline().parameters.TaskObject.ExecutionUid), \r\n         '\",\"RunId\":\"', \r\n         string(pipeline().RunId), \r\n         '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"'\r\n         , string(pipeline().TriggerTime), \r\n         '\",\"EndDateTimeOffSet\":\"', \r\n         string(utcnow()), '\",\"Comment\":\"', \r\n         concat(pipeline().Pipeline, 'Failed'), \r\n         '\",\"Status\":\"Failed\",\"NumberOfRetries\":\"', \r\n         string(pipeline().parameters.TaskObject.NumberOfRetries),\r\n         '\"}'\r\n    )\r\n)"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               },
+               {
+                  "dependsOn": [
+                     {
+                        "activity": "Switch Load Type",
+                        "dependencyConditions": [
+                           "Succeeded"
+                        ]
+                     }
+                  ],
+                  "name": "Pipeline AF Log - Succeed",
+                  "type": "ExecutePipeline",
+                  "typeProperties": {
+                     "parameters": {
+                        "Body": {
+                           "type": "Expression",
+                           "value": "@json(concat('{\"TaskInstanceId\":\"', string(pipeline().parameters.TaskObject.TaskInstanceId), '\",\"ExecutionUid\":\"', string(pipeline().parameters.TaskObject.ExecutionUid), '\",\"RunId\":\"', string(pipeline().RunId), '\",\"LogTypeId\":1,\"LogSource\":\"ADF\",\"ActivityType\":\"Data-Movement-Master\",\"StartDateTimeOffSet\":\"', string(pipeline().TriggerTime), '\",\"EndDateTimeOffSet\":\"', string(utcnow()), '\",\"Comment\":\"\",\"Status\":\"Complete\",\"NumberOfRetries\":\"', string(pipeline().parameters.TaskObject.NumberOfRetries),'\"}'))"
+                        },
+                        "FunctionName": "Log",
+                        "Method": "Post"
+                     },
+                     "pipeline": {
+                        "referenceName": "SPL_AzureFunction",
+                        "type": "PipelineReference"
+                     },
+                     "waitOnCompletion": true
+                  },
+                  "userProperties": [ ]
+               }
+            ],
+            "annotations": [ ],
+            "folder": {
+               "name": "[concat('ADS Go Fast/Data Movement/', parameters('integrationRuntimeShortName'))]"
+            },
+            "lastPublishTime": "2020-08-04T12:40:45Z",
+            "parameters": {
+               "TaskObject": {
+                  "defaultValue": {
+                     "DataFactory": {
+                        "ADFPipeline": "AZ_SQL_AZ_Storage_Parquet_IRA",
+                        "Id": 1,
+                        "Name": "adsgofastdatakakeacceladf",
+                        "ResourceGroup": "AdsGoFastDataLakeAccel",
+                        "SubscriptionId": "035a1364-f00d-48e2-b582-4fe125905ee3"
+                     },
+                     "DegreeOfCopyParallelism": 1,
+                     "Enabled": 1,
+                     "ExecutionUid": "2c5924ee-b855-4d2b-bb7e-4f5dde4c4dd3",
+                     "KeyVaultBaseUrl": "https://adsgofastkeyvault.vault.azure.net/",
+                     "NumberOfRetries": 111,
+                     "ScheduleMasterId": 2,
+                     "Source": {
+                        "Database": {
+                           "AuthenticationType": "MSI",
+                           "Name": "AWSample",
+                           "SystemName": "adsgofastdatakakeaccelsqlsvr.database.windows.net"
+                        },
+                        "Extraction": {
+                           "FullOrIncremental": "Full",
+                           "IncrementalType": null,
+                           "TableName": "SalesOrderHeader",
+                           "TableSchema": "SalesLT",
+                           "Type": "Table"
+                        },
+                        "Type": "Azure SQL"
+                     },
+                     "Target": {
+                        "DataFileName": "SalesLT.SalesOrderHeader.parquet",
+                        "FirstRowAsHeader": null,
+                        "MaxConcorrentConnections": null,
+                        "RelativePath": "/AwSample/SalesLT/SalesOrderHeader/2020/7/9/14/12/",
+                        "SchemaFileName": "SalesLT.SalesOrderHeader",
+                        "SheetName": null,
+                        "SkipLineCount": null,
+                        "StorageAccountAccessMethod": "MSI",
+                        "StorageAccountContainer": "datalakeraw",
+                        "StorageAccountName": "https://adsgofastdatalakeaccelst.blob.core.windows.net",
+                        "Type": "Azure Blob"
+                     },
+                     "TaskGroupConcurrency": 10,
+                     "TaskGroupPriority": 0,
+                     "TaskInstanceId": 75,
+                     "TaskMasterId": 12,
+                     "TaskStatus": "Untried",
+                     "TaskType": "SQL Database to Azure Storage"
+                  },
+                  "type": "object"
+               }
+            },
+            "variables": {
+               "SQLStatement": {
+                  "type": "String"
+               }
+            }
+         },
+         "type": "Microsoft.DataFactory/factories/pipelines"
+      }
+   ]
+}

--- a/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/main.tf
+++ b/solution/DeploymentV2/terraform/modules/data_factory_pipelines_selfhosted/main.tf
@@ -1,9 +1,9 @@
-resource "azurerm_resource_group_template_deployment" "azure_pipelines" {
+resource "azurerm_resource_group_template_deployment" "sh_pipelines_level_0" {
   for_each            = {
-    for pipeline in fileset(path.module, "arm/*.json"):  
+    for pipeline in fileset(path.module, "arm/GPL0_*.json"):  
     pipeline => pipeline 
   }
-  name                = "${replace(replace(each.value, ".json", ""), "arm/", "")}_${var.integration_runtime_short_name}_${var.name_suffix}"
+  name                = substr(sha256("${replace(replace(each.value, ".json", ""), "arm/", "")}_${var.integration_runtime_short_name}_${var.name_suffix}"), 0,30)
   resource_group_name = var.resource_group_name
   deployment_mode     = "Incremental"
   parameters_content = jsonencode({
@@ -19,7 +19,63 @@ resource "azurerm_resource_group_template_deployment" "azure_pipelines" {
     "sharedKeyVaultUri" = {
       value = var.shared_keyvault_uri
     },
-    
   })
   template_content = file("${path.module}/${each.value}")
+}
+
+resource "azurerm_resource_group_template_deployment" "sh_pipelines_level_1" {
+  for_each            = {
+    for pipeline in fileset(path.module, "arm/GPL1_*.json"):  
+    pipeline => pipeline 
+  }
+  name                = substr(sha256("${replace(replace(each.value, ".json", ""), "arm/", "")}_${var.integration_runtime_short_name}_${var.name_suffix}"), 0,30)
+  resource_group_name = var.resource_group_name
+  deployment_mode     = "Incremental"
+  parameters_content = jsonencode({
+    "dataFactoryName" = {
+      value = var.data_factory_name
+    },    
+    "integrationRuntimeName" = {
+      value = var.integration_runtime_name
+    },
+    "integrationRuntimeShortName" = {
+      value = var.integration_runtime_short_name
+    },
+    "sharedKeyVaultUri" = {
+      value = var.shared_keyvault_uri
+    },
+  })
+  template_content = file("${path.module}/${each.value}")
+  depends_on = [
+    azurerm_resource_group_template_deployment.sh_pipelines_level_0
+  ]  
+}
+
+resource "azurerm_resource_group_template_deployment" "sh_pipelines" {
+  for_each            = {
+    for pipeline in fileset(path.module, "arm/GPL_*.json"):  
+    pipeline => pipeline 
+  }
+  name                = substr(sha256("${replace(replace(each.value, ".json", ""), "arm/", "")}_${var.integration_runtime_short_name}_${var.name_suffix}"), 0,30)
+  resource_group_name = var.resource_group_name
+  deployment_mode     = "Incremental"
+  parameters_content = jsonencode({
+    "dataFactoryName" = {
+      value = var.data_factory_name
+    },    
+    "integrationRuntimeName" = {
+      value = var.integration_runtime_name
+    },
+    "integrationRuntimeShortName" = {
+      value = var.integration_runtime_short_name
+    },
+    "sharedKeyVaultUri" = {
+      value = var.shared_keyvault_uri
+    },
+  })
+  template_content = file("${path.module}/${each.value}")
+  depends_on = [
+    azurerm_resource_group_template_deployment.sh_pipelines_level_0,
+    azurerm_resource_group_template_deployment.sh_pipelines_level_1
+  ]
 }

--- a/solution/DeploymentV2/terraform/outputs.tf
+++ b/solution/DeploymentV2/terraform/outputs.tf
@@ -50,6 +50,6 @@ output "subscription_id" {
 output "purview_name" {
   value = local.purview_name
 }
-output "purview_sp_appid" {
-  value = azuread_service_principal.purview_ir[0].application_id
+output "purview_sp_name" {
+  value = local.purview_ir_app_reg_name
 }

--- a/solution/DeploymentV2/terraform/private_dns.tf
+++ b/solution/DeploymentV2/terraform/private_dns.tf
@@ -125,7 +125,7 @@ resource "azurerm_private_dns_zone" "synapse_gateway" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_gateway" {
-  count                 = (var.is_vnet_isolated && var.deploy_sentinel ? 1 : 0)
+  count                 = (var.is_vnet_isolated && var.deploy_sentinel  ? 1 : 0)
   name                  = "${local.vnet_name}-synapsegateway"
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.synapse_gateway[0].name
@@ -133,13 +133,13 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse_gateway" {
 }
 
 resource "azurerm_private_dns_zone" "synapse_sql" {
-  count               = (var.is_vnet_isolated && var.deploy_sentinel ? 1 : 0)
+  count               = (var.is_vnet_isolated && var.deploy_sentinel  ? 1 : 0)
   name                = "privatelink.sql.azuresynapse.net"
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_sql" {
-  count                 = (var.is_vnet_isolated && var.deploy_sentinel ? 1 : 0)
+  count                 = (var.is_vnet_isolated && var.deploy_sentinel  ? 1 : 0)
   name                  = "${local.vnet_name}-synapsesql"
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.synapse_sql[0].name
@@ -147,13 +147,13 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse_sql" {
 }
 
 resource "azurerm_private_dns_zone" "synapse_studio" {
-  count               = (var.is_vnet_isolated && var.deploy_sentinel ? 1 : 0)
+  count               = (var.is_vnet_isolated && var.deploy_sentinel  ? 1 : 0)
   name                = "privatelink.dev.azuresynapse.net"
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_studio" {
-  count                 = (var.is_vnet_isolated && var.deploy_sentinel ? 1 : 0)
+  count                 = (var.is_vnet_isolated && var.deploy_sentinel  ? 1 : 0)
   name                  = "${local.vnet_name}-synapsestudio"
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.synapse_studio[0].name

--- a/solution/DeploymentV2/terraform/private_dns.tf
+++ b/solution/DeploymentV2/terraform/private_dns.tf
@@ -125,7 +125,7 @@ resource "azurerm_private_dns_zone" "synapse_gateway" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_gateway" {
-  count                 = (var.is_vnet_isolated && var.deploy_sentinel  ? 1 : 0)
+  count                 = (var.is_vnet_isolated && var.deploy_sentinel ? 1 : 0)
   name                  = "${local.vnet_name}-synapsegateway"
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.synapse_gateway[0].name
@@ -133,13 +133,13 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse_gateway" {
 }
 
 resource "azurerm_private_dns_zone" "synapse_sql" {
-  count               = (var.is_vnet_isolated && var.deploy_sentinel  ? 1 : 0)
+  count               = (var.is_vnet_isolated && var.deploy_sentinel ? 1 : 0)
   name                = "privatelink.sql.azuresynapse.net"
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_sql" {
-  count                 = (var.is_vnet_isolated && var.deploy_sentinel  ? 1 : 0)
+  count                 = (var.is_vnet_isolated && var.deploy_sentinel ? 1 : 0)
   name                  = "${local.vnet_name}-synapsesql"
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.synapse_sql[0].name
@@ -147,13 +147,13 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse_sql" {
 }
 
 resource "azurerm_private_dns_zone" "synapse_studio" {
-  count               = (var.is_vnet_isolated && var.deploy_sentinel  ? 1 : 0)
+  count               = (var.is_vnet_isolated && var.deploy_sentinel ? 1 : 0)
   name                = "privatelink.dev.azuresynapse.net"
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_studio" {
-  count                 = (var.is_vnet_isolated && var.deploy_sentinel  ? 1 : 0)
+  count                 = (var.is_vnet_isolated && var.deploy_sentinel ? 1 : 0)
   name                  = "${local.vnet_name}-synapsestudio"
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.synapse_studio[0].name

--- a/solution/DeploymentV2/terraform/purview.tf
+++ b/solution/DeploymentV2/terraform/purview.tf
@@ -47,19 +47,19 @@ resource "azurerm_private_endpoint" "purview_account_private_endpoint_with_dns" 
 
 // Create an IR service principal (private linked resources can't use the azure hosted IRs)
 resource "azuread_application" "purview_ir" {
-  count        = var.deploy_purview && var.is_vnet_isolated ? 1 : 0
-  display_name = local.purview_ir_app_reg_name
-  owners       = [data.azurerm_client_config.current.object_id]
+  count           = var.deploy_purview && var.is_vnet_isolated  ? 1 : 0
+  display_name    = local.purview_ir_app_reg_name
+  owners           = [data.azurerm_client_config.current.object_id]
 }
 
 resource "azuread_service_principal" "purview_ir" {
-  count          = var.deploy_purview && var.is_vnet_isolated ? 1 : 0
+  count           = var.deploy_purview && var.is_vnet_isolated  ? 1 : 0
   application_id = azuread_application.purview_ir[0].application_id
 }
 
 
 resource "azuread_application_password" "purview_ir" {
-  count                 = var.deploy_purview && var.is_vnet_isolated ? 1 : 0
+  count           = var.deploy_purview && var.is_vnet_isolated  ? 1 : 0
   application_object_id = azuread_application.purview_ir[0].object_id
 }
 

--- a/solution/DeploymentV2/terraform/purview.tf
+++ b/solution/DeploymentV2/terraform/purview.tf
@@ -47,19 +47,19 @@ resource "azurerm_private_endpoint" "purview_account_private_endpoint_with_dns" 
 
 // Create an IR service principal (private linked resources can't use the azure hosted IRs)
 resource "azuread_application" "purview_ir" {
-  count           = var.deploy_purview && var.is_vnet_isolated  ? 1 : 0
-  display_name    = local.purview_ir_app_reg_name
-  owners           = [data.azurerm_client_config.current.object_id]
+  count        = var.deploy_purview && var.is_vnet_isolated ? 1 : 0
+  display_name = local.purview_ir_app_reg_name
+  owners       = [data.azurerm_client_config.current.object_id]
 }
 
 resource "azuread_service_principal" "purview_ir" {
-  count           = var.deploy_purview && var.is_vnet_isolated  ? 1 : 0
+  count          = var.deploy_purview && var.is_vnet_isolated ? 1 : 0
   application_id = azuread_application.purview_ir[0].application_id
 }
 
 
 resource "azuread_application_password" "purview_ir" {
-  count           = var.deploy_purview && var.is_vnet_isolated  ? 1 : 0
+  count                 = var.deploy_purview && var.is_vnet_isolated ? 1 : 0
   application_object_id = azuread_application.purview_ir[0].object_id
 }
 

--- a/solution/DeploymentV2/terraform/security.tf
+++ b/solution/DeploymentV2/terraform/security.tf
@@ -13,7 +13,7 @@ resource "azurerm_log_analytics_workspace" "log_analytics_workspace" {
 }
 
 resource "azurerm_log_analytics_solution" "sentinel" {
-  count = var.deploy_sentinel ? 1 : 0
+  count                 = var.deploy_sentinel ? 1 : 0
   solution_name         = "SecurityInsights"
   location              = var.resource_location
   resource_group_name   = var.resource_group_name

--- a/solution/DeploymentV2/terraform/security.tf
+++ b/solution/DeploymentV2/terraform/security.tf
@@ -13,7 +13,7 @@ resource "azurerm_log_analytics_workspace" "log_analytics_workspace" {
 }
 
 resource "azurerm_log_analytics_solution" "sentinel" {
-  count                 = var.deploy_sentinel ? 1 : 0
+  count = var.deploy_sentinel ? 1 : 0
   solution_name         = "SecurityInsights"
   location              = var.resource_location
   resource_group_name   = var.resource_group_name

--- a/solution/DeploymentV2/terraform/storage_blob.tf
+++ b/solution/DeploymentV2/terraform/storage_blob.tf
@@ -12,7 +12,7 @@ resource "azurerm_storage_account" "blob" {
   min_tls_version          = "TLS1_2"
   allow_blob_public_access = "false"
   network_rules {
-    default_action = "Deny"
+    default_action = "Allow"
     bypass         = ["Metrics", "AzureServices"]
     ip_rules       = [var.ip_address] // This is required to allow us to create the initial containers
   }

--- a/solution/DeploymentV2/terraform/synapse.tf
+++ b/solution/DeploymentV2/terraform/synapse.tf
@@ -2,13 +2,13 @@
 # Workspace
 # --------------------------------------------------------------------------------------------------------------------
 resource "azurerm_storage_data_lake_gen2_filesystem" "dlfs" {
-  count = var.deploy_adls && var.deploy_synapse ? 1 : 0
+  count              = var.deploy_adls && var.deploy_synapse ? 1 : 0
   name               = local.synapse_data_lake_name
   storage_account_id = azurerm_storage_account.adls[0].id
 }
 
 resource "azurerm_synapse_workspace" "synapse" {
-  count = var.deploy_adls && var.deploy_synapse ? 1 : 0
+  count                                = var.deploy_adls && var.deploy_synapse ? 1 : 0
   name                                 = local.synapse_workspace_name
   resource_group_name                  = var.resource_group_name
   location                             = var.resource_location
@@ -33,24 +33,24 @@ resource "azurerm_synapse_workspace" "synapse" {
 # SQL Dedicated Pool
 # --------------------------------------------------------------------------------------------------------------------
 resource "azurerm_synapse_sql_pool" "synapse_sql_pool" {
-  count = var.deploy_adls && var.deploy_synapse && var.deploy_synapse_sqlpool ? 1 : 0    
+  count                = var.deploy_adls && var.deploy_synapse && var.deploy_synapse_sqlpool ? 1 : 0
   name                 = local.synapse_workspace_name
   synapse_workspace_id = azurerm_synapse_workspace.synapse[0].id
   sku_name             = var.synapse_sku
   create_mode          = "Default"
-  tags = local.tags
+  tags                 = local.tags
   lifecycle {
     ignore_changes = [
       tags
     ]
-  }  
+  }
 }
 
 # --------------------------------------------------------------------------------------------------------------------
 # Spark Pool
 # --------------------------------------------------------------------------------------------------------------------
 resource "azurerm_synapse_spark_pool" "synapse_spark_pool" {
-  count = var.deploy_adls && var.deploy_synapse && var.deploy_synapse_sparkpool ? 1 : 0    
+  count                = var.deploy_adls && var.deploy_synapse && var.deploy_synapse_sparkpool ? 1 : 0
   name                 = local.synapse_sppool_name
   synapse_workspace_id = azurerm_synapse_workspace.synapse[0].id
   node_size_family     = "MemoryOptimized"
@@ -70,7 +70,7 @@ resource "azurerm_synapse_spark_pool" "synapse_spark_pool" {
     ignore_changes = [
       tags
     ]
-  }  
+  }
 }
 
 # --------------------------------------------------------------------------------------------------------------------
@@ -88,7 +88,7 @@ resource "azurerm_synapse_firewall_rule" "cicd" {
 # Synapse Workspace Firewall Rules (Allow Public Access)
 # --------------------------------------------------------------------------------------------------------------------
 resource "azurerm_synapse_firewall_rule" "public_access" {
-  count                = var.deploy_adls && var.deploy_synapse && var.allow_public_access_to_synapse_studio? 1 : 0
+  count                = var.deploy_adls && var.deploy_synapse && var.allow_public_access_to_synapse_studio ? 1 : 0
   name                 = "AllowAll"
   synapse_workspace_id = azurerm_synapse_workspace.synapse[0].id
   start_ip_address     = "0.0.0.0"
@@ -130,7 +130,7 @@ resource "azurerm_synapse_managed_private_endpoint" "adls" {
 # Network Settings to allow inbound private link traffic to the Synapse studio
 # https://docs.microsoft.com/en-us/azure/synapse-analytics/security/how-to-connect-to-workspace-from-restricted-network
 resource "azurerm_synapse_private_link_hub" "hub" {
-  count                = var.deploy_adls && var.deploy_synapse && var.is_vnet_isolated ? 1 : 0
+  count               = var.deploy_adls && var.deploy_synapse && var.is_vnet_isolated ? 1 : 0
   name                = "${local.synapse_workspace_name}plinkhub"
   resource_group_name = var.resource_group_name
   location            = var.resource_location
@@ -138,7 +138,7 @@ resource "azurerm_synapse_private_link_hub" "hub" {
 
 
 resource "azurerm_private_endpoint" "synapse_web" {
-  count                = var.deploy_adls && var.deploy_synapse && var.is_vnet_isolated ? 1 : 0
+  count               = var.deploy_adls && var.deploy_synapse && var.is_vnet_isolated ? 1 : 0
   name                = "${local.synapse_workspace_name}-web-plink"
   location            = var.resource_location
   resource_group_name = var.resource_group_name
@@ -165,7 +165,7 @@ resource "azurerm_private_endpoint" "synapse_web" {
 }
 
 resource "azurerm_private_endpoint" "synapse_dev" {
-  count                = var.deploy_adls && var.deploy_synapse && var.is_vnet_isolated ? 1 : 0
+  count               = var.deploy_adls && var.deploy_synapse && var.is_vnet_isolated ? 1 : 0
   name                = "${local.synapse_workspace_name}-dev-plink"
   location            = var.resource_location
   resource_group_name = var.resource_group_name
@@ -192,7 +192,7 @@ resource "azurerm_private_endpoint" "synapse_dev" {
 }
 
 resource "azurerm_private_endpoint" "synapse_sql" {
-  count                = var.deploy_adls && var.deploy_synapse && var.is_vnet_isolated ? 1 : 0
+  count               = var.deploy_adls && var.deploy_synapse && var.is_vnet_isolated ? 1 : 0
   name                = "${local.synapse_workspace_name}-sql-plink"
   location            = var.resource_location
   resource_group_name = var.resource_group_name
@@ -219,7 +219,7 @@ resource "azurerm_private_endpoint" "synapse_sql" {
 }
 
 resource "azurerm_private_endpoint" "synapse_sqlondemand" {
-  count                = var.deploy_adls && var.deploy_synapse && var.is_vnet_isolated ? 1 : 0
+  count               = var.deploy_adls && var.deploy_synapse && var.is_vnet_isolated ? 1 : 0
   name                = "${local.synapse_workspace_name}-sqld-plink"
   location            = var.resource_location
   resource_group_name = var.resource_group_name
@@ -253,7 +253,7 @@ resource "azurerm_private_endpoint" "synapse_sqlondemand" {
 # --------------------------------------------------------------------------------------------------------------------
 resource "azurerm_monitor_diagnostic_setting" "synapse_diagnostic_logs" {
   count = var.deploy_adls && var.deploy_synapse ? 1 : 0
-  name                           = "diagnosticlogs"
+  name  = "diagnosticlogs"
   # ignore_changes is here given the bug  https://github.com/terraform-providers/terraform-provider-azurerm/issues/10388
   lifecycle {
     ignore_changes = [log, metric]
@@ -300,7 +300,7 @@ resource "azurerm_monitor_diagnostic_setting" "synapse_diagnostic_logs" {
       days    = 0
       enabled = true
     }
-  }   
+  }
   log {
     category = "IntegrationTriggerRuns"
     enabled  = true
@@ -308,7 +308,7 @@ resource "azurerm_monitor_diagnostic_setting" "synapse_diagnostic_logs" {
       days    = 0
       enabled = true
     }
-  }     
+  }
 
   metric {
     category = "AllMetrics"

--- a/solution/DeploymentV2/terraform/vars.tf
+++ b/solution/DeploymentV2/terraform/vars.tf
@@ -409,7 +409,7 @@ variable "app_service_sku" {
 
 variable "synapse_sku" {
   description = "The sku/scale of the Synapse SQL Pool"
-  default = "DW100c"
+  default     = "DW100c"
   type        = string
   validation {
     condition     = contains(["DW100c", "DW200c", "DW300c", "DW400c", "DW500c", "DW1000c", "DW1500c", "DW2000c", "DW2500c", "DW3000c"], var.synapse_sku)

--- a/solution/DeploymentV2/terraform/vars.tf
+++ b/solution/DeploymentV2/terraform/vars.tf
@@ -54,6 +54,12 @@ variable "domain" {
   description = "The AAD domain"
   type        = string
 }
+//Onprem linked services and pipelines won't be registered until you complete the IR registration and set this to true
+variable "is_onprem_datafactory_ir_registered" {
+  description = "Are all on-premise Integration runtimes configured?"
+  default     = false
+  type        = bool
+}
 
 variable "is_vnet_isolated" {
   description = "Whether to deploy the resources as vnet attached / private linked"
@@ -403,7 +409,7 @@ variable "app_service_sku" {
 
 variable "synapse_sku" {
   description = "The sku/scale of the Synapse SQL Pool"
-  default     = "DW100c"
+  default = "DW100c"
   type        = string
   validation {
     condition     = contains(["DW100c", "DW200c", "DW300c", "DW400c", "DW500c", "DW1000c", "DW1500c", "DW2000c", "DW2500c", "DW3000c"], var.synapse_sku)


### PR DESCRIPTION
*   Removed task type masters from the deployment process (now done in the DBUp tool)
*   Added MSI - SQL access scripts to deployment script
*   Added updated ADF pipelines based on the pattern generation approach
*   Added missing transientin storage container
*   Fixed log analytics workspace and logging not showing in web app
*   Allowed for performing a 2 step installation of on-prem ADF - IRS
    *   First pass will register IRs in data factory but not configure pipelines
    *   After installing on prem IRs, sencond pass can be run to configure ADF assets dependent on IR running.