### PR TITLE
Updated app to support integration runtimes

### DIFF
--- a/solution/WebApplication/WebApplication.DataAccess/Models/AdsGoFastContext.cs
+++ b/solution/WebApplication/WebApplication.DataAccess/Models/AdsGoFastContext.cs
@@ -25,6 +25,7 @@ namespace WebApplication.Models
         public virtual DbSet<AzureStorageChangeFeedCursor> AzureStorageChangeFeedCursor { get; set; }
         public virtual DbSet<AzureStorageListing> AzureStorageListing { get; set; }
         public virtual DbSet<DataFactory> DataFactory { get; set; }
+        public virtual DbSet<IntegrationRuntime> IntegrationRuntime { get; set; }
         public virtual DbSet<Execution> Execution { get; set; }
         public virtual DbSet<FrameworkTaskRunner> FrameworkTaskRunner { get; set; }
         public virtual DbSet<ScheduleInstance> ScheduleInstance { get; set; }
@@ -347,6 +348,14 @@ namespace WebApplication.Models
                     .IsUnicode(false);
             });
 
+            modelBuilder.Entity<IntegrationRuntime>(entity =>
+            {
+                entity.Property(e => e.IntegrationRuntimeName)
+                    .HasMaxLength(255)
+                    .IsUnicode(false);
+            });
+
+
             modelBuilder.Entity<Execution>(entity =>
             {
                 entity.HasKey(e => e.ExecutionUid)
@@ -654,11 +663,6 @@ namespace WebApplication.Models
 
                 entity.Property(e => e.TargetType)
                     .IsRequired()
-                    .HasMaxLength(128);
-
-                entity.Property(e => e.TaskDatafactoryIr)
-                    .IsRequired()
-                    .HasColumnName("TaskDatafactoryIR")
                     .HasMaxLength(128);
 
                 entity.Property(e => e.TaskInstanceJsonSchema).IsUnicode(false);

--- a/solution/WebApplication/WebApplication.DataAccess/Models/IntegrationRuntime.cs
+++ b/solution/WebApplication/WebApplication.DataAccess/Models/IntegrationRuntime.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace WebApplication.Models
+{
+    public class IntegrationRuntime
+    {
+        public int IntegrationRuntimeId { get; set; }
+        [Required(AllowEmptyStrings = false, ErrorMessage = "Please input valid Name")]
+        public string IntegrationRuntimeName { get; set; }
+        public long DataFactoryId { get; set; }
+        [Display(Name = "Is Active")]
+        public bool ActiveYn { get; set; }
+
+        public virtual DataFactory DataFactory { get; set; }
+    }
+}

--- a/solution/WebApplication/WebApplication.DataAccess/Models/TaskTypeMapping.cs
+++ b/solution/WebApplication/WebApplication.DataAccess/Models/TaskTypeMapping.cs
@@ -25,9 +25,6 @@ namespace WebApplication.Models
         [Display(Name = "Target Type")]
         [Required(AllowEmptyStrings = false, ErrorMessage = "Please input a valid Target Type")]
         public string TargetType { get; set; }
-        [Display(Name = "Data Factory IR")]
-        [Required(AllowEmptyStrings = false, ErrorMessage = "Please input valid Data Factory")]
-        public string TaskDatafactoryIr { get; set; }
         [Display(Name = "Task Type Json")]
         public string TaskTypeJson { get; set; }
         [Display(Name = "Is Active")]

--- a/solution/WebApplication/WebApplication/Controllers/IntegrationRuntimeController.cs
+++ b/solution/WebApplication/WebApplication/Controllers/IntegrationRuntimeController.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Dynamic.Core;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using WebApplication.Services;
+using WebApplication.Framework;
+using WebApplication.Models;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+
+namespace WebApplication.Controllers
+{
+    public partial class IntegrationRuntimeController : BaseController
+    {
+        protected readonly AdsGoFastContext _context;
+        
+
+        public IntegrationRuntimeController(AdsGoFastContext context, ISecurityAccessProvider securityAccessProvider, IEntityRoleProvider roleProvider) : base(securityAccessProvider, roleProvider)
+        {
+            Name = "IntegrationRuntime";
+            _context = context;
+        }
+
+        // GET: IntegrationRuntime
+        public async Task<IActionResult> Index()
+        {
+            var adsGoFastContext = _context.IntegrationRuntime;
+            return View(await adsGoFastContext.ToListAsync());
+        }
+
+        // GET: IntegrationRuntime/Details/5
+        [ChecksUserAccess]
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var ir = await _context.IntegrationRuntime
+                .Include(x=>x.DataFactory)
+                .FirstOrDefaultAsync(m => m.IntegrationRuntimeId == id);
+            if (ir == null)
+                return NotFound();
+            if (!await CanPerformCurrentActionOnRecord(ir))
+                return new ForbidResult();
+
+
+            return View(ir);
+        }
+
+        // GET: IntegrationRuntime/Create
+        public IActionResult Create()
+        {
+            ViewData["DataFactories"] = new SelectList(_context.DataFactory.OrderBy(x=>x.Name), "Id", "Name");
+            IntegrationRuntime ir = new IntegrationRuntime();
+            ir.ActiveYn = true;
+            return View(ir);
+        }
+
+        // POST: IntegrationRuntime/Create
+        // To protect from overposting attacks, enable the specific properties you want to bind to, for 
+        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [ChecksUserAccess]
+        public async Task<IActionResult> Create([Bind("IntegrationRuntimeId,IntegrationRuntimeName,ActiveYn,DataFactoryId")] IntegrationRuntime ir)
+        {
+            if (ModelState.IsValid)
+            {
+                _context.Add(ir);
+                if (!await CanPerformCurrentActionOnRecord(ir))
+                {
+                    return new ForbidResult();
+                }
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(IndexDataTable));
+            }
+            ViewData["DataFactories"] = new SelectList(_context.DataFactory.OrderBy(x => x.Name), "Id", "Name");
+            return View(ir);
+        }
+
+        // GET: IntegrationRuntime/Edit/5
+        [ChecksUserAccess()]
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var IntegrationRuntime = await _context.IntegrationRuntime.FindAsync(id);
+            if (IntegrationRuntime == null)
+                return NotFound();
+
+            if (!await CanPerformCurrentActionOnRecord(IntegrationRuntime))
+                return new ForbidResult();
+            ViewData["DataFactories"] = new SelectList(_context.DataFactory.OrderBy(x => x.Name), "Id", "Name");
+            return View(IntegrationRuntime);
+        }
+
+        // POST: IntegrationRuntime/Edit/5
+        // To protect from overposting attacks, enable the specific properties you want to bind to, for 
+        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [ChecksUserAccess]
+        public async Task<IActionResult> Edit(int id, [Bind("IntegrationRuntimeId,IntegrationRuntimeName,ActiveYn,DataFactoryId")] IntegrationRuntime integrationRuntime)
+        {
+            if (id != integrationRuntime.IntegrationRuntimeId)
+            {
+                return NotFound();
+            }
+
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Update(integrationRuntime);
+
+                    if (!await CanPerformCurrentActionOnRecord(integrationRuntime))
+                        return new ForbidResult();
+			
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    if (!IntegrationRuntimeExists(integrationRuntime.IntegrationRuntimeId))
+                    {
+                        return NotFound();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                return RedirectToAction(nameof(IndexDataTable));
+            }
+            ViewData["DataFactories"] = new SelectList(_context.DataFactory.OrderBy(x => x.Name), "Id", "Name");
+            return View(integrationRuntime);
+        }
+
+        // GET: IntegrationRuntime/Delete/5
+        [ChecksUserAccess]
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var IntegrationRuntime = await _context.IntegrationRuntime
+                .FirstOrDefaultAsync(m => m.IntegrationRuntimeId == id);
+            if (IntegrationRuntime == null)
+                return NotFound();
+		
+            if (!await CanPerformCurrentActionOnRecord(IntegrationRuntime))
+                return new ForbidResult();
+
+            return View(IntegrationRuntime);
+        }
+
+        // POST: IntegrationRuntime/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ChecksUserAccess()]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            var integrationRuntime = await _context.IntegrationRuntime.FindAsync(id);
+
+            if (!await CanPerformCurrentActionOnRecord(integrationRuntime))
+                return new ForbidResult();
+		
+            _context.IntegrationRuntime.Remove(integrationRuntime);
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(IndexDataTable));
+        }
+
+        private bool IntegrationRuntimeExists(long id)
+        {
+            return _context.IntegrationRuntime.Any(e => e.IntegrationRuntimeId == id);
+        }
+
+        [ChecksUserAccess]
+        public IActionResult IndexDataTable()
+        {
+            return View();
+        }
+
+        public JObject GridCols()
+        {
+            JObject GridOptions = new JObject();
+
+            JArray cols = new JArray();
+            cols.Add(JObject.Parse("{ 'data':'IntegrationRuntimeId', 'name':'Id', 'autoWidth':true }"));
+            cols.Add(JObject.Parse("{ 'data':'IntegrationRuntimeName', 'name':'Name', 'autoWidth':true }"));
+            cols.Add(JObject.Parse("{ 'data':'DataFactoryId', 'name':'Data Factory', 'autoWidth':true }"));
+            cols.Add(JObject.Parse("{ 'data':'ActiveYn', 'name':'Is Active', 'autoWidth':true, 'ads_format':'bool'}"));
+
+            HumanizeColumns(cols);
+
+            JArray pkeycols = new JArray();
+            pkeycols.Add("IntegrationRuntimeId");
+
+            JArray Navigations = new JArray();
+
+            GridOptions["GridColumns"] = cols;
+            GridOptions["ModelName"] = "IntegrationRuntime";
+            GridOptions["PrimaryKeyColumns"] = pkeycols;
+            GridOptions["Navigations"] = Navigations;
+            //GridOptions["CrudButtons"] = GetSecurityFilteredActions("Create,Edit,Details,Delete");
+            GridOptions["CrudButtons"] = new JArray("Create", "Edit", "Details", "Delete");
+
+            return GridOptions;
+
+
+        }
+
+        [ChecksUserAccess]
+        public ActionResult GetGridOptions()
+        {
+            return new OkObjectResult(JsonConvert.SerializeObject(GridCols()));
+        }
+
+        [ChecksUserAccess]
+        public async Task<ActionResult> GetGridData()
+        {
+            try
+            {
+                string draw = Request.Form["draw"];
+                string start = Request.Form["start"];
+                string length = Request.Form["length"];
+                string sortColumn = Request.Form["columns[" + Request.Form["order[0][column]"] + "][data]"];
+                string sortColumnDir = Request.Form["order[0][dir]"];
+                string searchValue = Request.Form["search[value]"];
+
+                //Paging Size (10,20,50,100)    
+                int pageSize = length != null ? Convert.ToInt32(length) : 0;
+                int skip = start != null ? Convert.ToInt32(start) : 0;
+                int recordsTotal = 0;
+
+                // Getting all Customer data    
+                var modelDataAll = (from temptable in _context.IntegrationRuntime
+                                    select temptable);
+
+                //Sorting    
+                if (!(string.IsNullOrEmpty(sortColumn) && string.IsNullOrEmpty(sortColumnDir)))
+                {
+                    modelDataAll = modelDataAll.OrderBy(sortColumn + " " + sortColumnDir);
+                }
+                //Search    
+                if (!string.IsNullOrEmpty(searchValue))
+                {
+                    modelDataAll = modelDataAll.Where(m => m.IntegrationRuntimeName == searchValue);
+                }
+
+                //total number of rows count     
+                recordsTotal = await modelDataAll.CountAsync();
+                //Paging     
+                var data = await modelDataAll.Skip(skip).Take(pageSize).ToListAsync();
+                //Returning Json Data    
+                return new OkObjectResult(JsonConvert.SerializeObject(new { draw = draw, recordsFiltered = recordsTotal, recordsTotal = recordsTotal, data = data }, new Newtonsoft.Json.Converters.StringEnumConverter()));
+
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+
+        }
+    }
+}

--- a/solution/WebApplication/WebApplication/Controllers/TaskGroupController.cs
+++ b/solution/WebApplication/WebApplication/Controllers/TaskGroupController.cs
@@ -89,7 +89,7 @@ namespace WebApplication.Controllers
                 await _context.SaveChangesAsync();
                 return Redirect(returnUrl);
             }
-        ViewData["SubjectAreaId"] = new SelectList(_context.SubjectArea.OrderBy(x=>x.SubjectAreaId), "SubjectAreaId", "SubjectAreaId", taskGroup.SubjectAreaId);
+            ViewData["SubjectAreaId"] = new SelectList(_context.SubjectArea.OrderBy(x=>x.SubjectAreaId), "SubjectAreaId", "SubjectAreaId", taskGroup.SubjectAreaId);
             return View(taskGroup);
         }
 
@@ -108,7 +108,7 @@ namespace WebApplication.Controllers
 
             if (!await CanPerformCurrentActionOnRecord(taskGroup))
                 return new ForbidResult();
-        ViewData["SubjectAreaId"] = new SelectList(_context.SubjectArea.OrderBy(x=>x.SubjectAreaId), "SubjectAreaId", "SubjectAreaId", taskGroup.SubjectAreaId);
+            ViewData["SubjectAreaId"] = new SelectList(_context.SubjectArea.OrderBy(x=>x.SubjectAreaId), "SubjectAreaId", "SubjectAreaId", taskGroup.SubjectAreaId);
             ViewBag.returnUrl = Request.Headers["Referer"].ToString();
             return View(taskGroup);
         }
@@ -151,7 +151,7 @@ namespace WebApplication.Controllers
 
                 return Redirect(returnUrl);
             }
-        ViewData["SubjectAreaId"] = new SelectList(_context.SubjectArea.OrderBy(x=>x.SubjectAreaId), "SubjectAreaId", "SubjectAreaId", taskGroup.SubjectAreaId);
+            ViewData["SubjectAreaId"] = new SelectList(_context.SubjectArea.OrderBy(x=>x.SubjectAreaId), "SubjectAreaId", "SubjectAreaId", taskGroup.SubjectAreaId);
             return View(taskGroup);
         }
 

--- a/solution/WebApplication/WebApplication/Controllers/TaskMasterController.cs
+++ b/solution/WebApplication/WebApplication/Controllers/TaskMasterController.cs
@@ -75,6 +75,8 @@ namespace WebApplication.Controllers
             }
             ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x => x.TaskTypeName), "TaskTypeId", "TaskTypeName");
             ViewData["DataFactoryId"] = new SelectList(_context.DataFactory.OrderBy(x => x.Name), "Id", "Name");
+            ViewData["IntegrationRuntimes"] = new SelectList(_context.IntegrationRuntime.OrderBy(x => x.IntegrationRuntimeName), "IntegrationRuntimeName", "IntegrationRuntimeName");
+            
             ViewBag.returnUrl = Request.Headers["Referer"].ToString();
             TaskMaster taskMaster = new TaskMaster();
             taskMaster.TaskMasterJson = "{}";
@@ -108,6 +110,7 @@ namespace WebApplication.Controllers
             ViewData["TaskGroupId"] = new SelectList(_context.TaskGroup.OrderBy(x => x.TaskGroupName), "TaskGroupId", "TaskGroupName", taskMaster.TaskGroupId);
             ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x => x.TaskTypeName), "TaskTypeId", "TaskTypeName", taskMaster.TaskTypeId);
             ViewData["DataFactoryId"] = new SelectList(_context.DataFactory.OrderBy(x => x.Name), "Id", "Name");
+            ViewData["IntegrationRuntimes"] = new SelectList(_context.IntegrationRuntime.OrderBy(x => x.IntegrationRuntimeName), "IntegrationRuntimeName", "IntegrationRuntimeName");
             return View(taskMaster);
         }
 
@@ -132,6 +135,7 @@ namespace WebApplication.Controllers
             ViewData["TaskGroupId"] = new SelectList(_context.TaskGroup.OrderBy(x => x.TaskGroupName), "TaskGroupId", "TaskGroupName", taskMaster.TaskGroupId);
             ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x => x.TaskTypeName), "TaskTypeId", "TaskTypeName", taskMaster.TaskTypeId);
             ViewData["DataFactoryId"] = new SelectList(_context.DataFactory.OrderBy(x => x.Name), "Id", "DataFactoryName");
+            ViewData["IntegrationRuntimes"] = new SelectList(_context.IntegrationRuntime.OrderBy(x => x.IntegrationRuntimeName), "IntegrationRuntimeName", "IntegrationRuntimeName");
             return View(taskMaster);
         }
 
@@ -178,6 +182,7 @@ namespace WebApplication.Controllers
             ViewData["TaskGroupId"] = new SelectList(_context.TaskGroup.OrderBy(x => x.TaskGroupName), "TaskGroupId", "TaskGroupName", taskMaster.TaskGroupId);
             ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x => x.TaskTypeName), "TaskTypeId", "TaskTypeName", taskMaster.TaskTypeId);
             ViewData["DataFactoryId"] = new SelectList(_context.DataFactory.OrderBy(x => x.Name), "Id", "DataFactoryName");
+            ViewData["IntegrationRuntimes"] = new SelectList(_context.IntegrationRuntime.OrderBy(x => x.IntegrationRuntimeName), "IntegrationRuntimeName", "IntegrationRuntimeName");
             return View(taskMaster);
         }
 
@@ -449,6 +454,7 @@ namespace WebApplication.Controllers
             ViewData["TargetSystemId"] = new SelectList(_context.SourceAndTargetSystems.OrderBy(t => t.SystemName), "SystemId", "SystemName", taskMaster.TargetSystemId);
             ViewData["ScheduleMasterId"] = new SelectList(_context.ScheduleMaster.OrderBy(t => t.ScheduleDesciption), "ScheduleMasterId", "ScheduleDesciption", taskMaster.ScheduleMasterId);
             ViewData["DataFactoryId"] = new SelectList(_context.DataFactory.OrderBy(x => x.Name), "Id", "Name");
+            ViewData["IntegrationRuntimes"] = new SelectList(_context.IntegrationRuntime.OrderBy(x => x.IntegrationRuntimeName), "IntegrationRuntimeName", "IntegrationRuntimeName");
             ViewBag.returnUrl = Request.Headers["Referer"].ToString();
             return View(taskMaster);
         }
@@ -491,6 +497,8 @@ namespace WebApplication.Controllers
             ViewData["TaskGroupId"] = new SelectList(_context.TaskGroup, "TaskGroupId", "TaskGroupName", taskMaster.TaskGroupId);
             ViewData["TaskTypeId"] = new SelectList(_context.TaskType, "TaskTypeId", "TaskTypeName", taskMaster.TaskTypeId);
             ViewData["DataFactoryId"] = new SelectList(_context.DataFactory.OrderBy(x => x.Name), "Id", "Name");
+            ViewData["IntegrationRuntimes"] = new SelectList(_context.IntegrationRuntime.OrderBy(x => x.IntegrationRuntimeName), "IntegrationRuntimeName", "IntegrationRuntimeName");
+
             return View(taskMaster);
         }
     }

--- a/solution/WebApplication/WebApplication/Controllers/TaskTypeMappingController.cs
+++ b/solution/WebApplication/WebApplication/Controllers/TaskTypeMappingController.cs
@@ -57,7 +57,7 @@ namespace WebApplication.Controllers
         public IActionResult Create()
         {
             ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x=>x.TaskTypeName), "TaskTypeId", "TaskTypeName");
-     TaskTypeMapping taskTypeMapping = new TaskTypeMapping();
+            TaskTypeMapping taskTypeMapping = new TaskTypeMapping();
             taskTypeMapping.ActiveYn = true;
             return View(taskTypeMapping);
         }
@@ -68,7 +68,7 @@ namespace WebApplication.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [ChecksUserAccess]
-        public async Task<IActionResult> Create([Bind("TaskTypeMappingId,TaskTypeId,MappingType,MappingName,SourceSystemType,SourceType,TargetSystemType,TargetType,TaskDatafactoryIr,TaskTypeJson,ActiveYn,TaskMasterJsonSchema,TaskInstanceJsonSchema")] TaskTypeMapping taskTypeMapping)
+        public async Task<IActionResult> Create([Bind("TaskTypeMappingId,TaskTypeId,MappingType,MappingName,SourceSystemType,SourceType,TargetSystemType,TargetType,TaskTypeJson,ActiveYn,TaskMasterJsonSchema,TaskInstanceJsonSchema")] TaskTypeMapping taskTypeMapping)
         {
             if (ModelState.IsValid)
             {
@@ -80,7 +80,7 @@ namespace WebApplication.Controllers
                 await _context.SaveChangesAsync();
                 return RedirectToAction(nameof(IndexDataTable));
             }
-        ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x=>x.TaskTypeName), "TaskTypeId", "TaskTypeName", taskTypeMapping.TaskTypeId);
+            ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x=>x.TaskTypeName), "TaskTypeId", "TaskTypeName", taskTypeMapping.TaskTypeId);
             return View(taskTypeMapping);
         }
 
@@ -99,7 +99,7 @@ namespace WebApplication.Controllers
 
             if (!await CanPerformCurrentActionOnRecord(taskTypeMapping))
                 return new ForbidResult();
-        ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x=>x.TaskTypeName), "TaskTypeId", "TaskTypeName", taskTypeMapping.TaskTypeId);
+            ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x=>x.TaskTypeName), "TaskTypeId", "TaskTypeName", taskTypeMapping.TaskTypeId);
             return View(taskTypeMapping);
         }
 
@@ -109,7 +109,7 @@ namespace WebApplication.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [ChecksUserAccess]
-        public async Task<IActionResult> Edit(int id, [Bind("TaskTypeMappingId,TaskTypeId,MappingType,MappingName,SourceSystemType,SourceType,TargetSystemType,TargetType,TaskDatafactoryIr,TaskTypeJson,ActiveYn,TaskMasterJsonSchema,TaskInstanceJsonSchema")] TaskTypeMapping taskTypeMapping)
+        public async Task<IActionResult> Edit(int id, [Bind("TaskTypeMappingId,TaskTypeId,MappingType,MappingName,SourceSystemType,SourceType,TargetSystemType,TargetType,TaskTypeJson,ActiveYn,TaskMasterJsonSchema,TaskInstanceJsonSchema")] TaskTypeMapping taskTypeMapping)
         {
             if (id != taskTypeMapping.TaskTypeMappingId)
             {
@@ -140,7 +140,7 @@ namespace WebApplication.Controllers
                 }
                 return RedirectToAction(nameof(IndexDataTable));
             }
-        ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x=>x.TaskTypeName), "TaskTypeId", "TaskTypeName", taskTypeMapping.TaskTypeId);
+            ViewData["TaskTypeId"] = new SelectList(_context.TaskType.OrderBy(x=>x.TaskTypeName), "TaskTypeId", "TaskTypeName", taskTypeMapping.TaskTypeId);
             return View(taskTypeMapping);
         }
 
@@ -205,7 +205,6 @@ namespace WebApplication.Controllers
             cols.Add(JObject.Parse("{ 'data':'TargetSystemType', 'name':'TargetSystemType', 'autoWidth':true }"));
             cols.Add(JObject.Parse("{ 'data':'SourceType', 'name':'TaskMasterJsonSourceType', 'autoWidth':true }"));
             cols.Add(JObject.Parse("{ 'data':'TargetType', 'name':'TaskMasterJsonTargetType', 'autoWidth':true }"));
-            cols.Add(JObject.Parse("{ 'data':'TaskDatafactoryIr', 'name':'DataFactoryIr', 'autoWidth':true }"));
 
             HumanizeColumns(cols);
 
@@ -370,7 +369,7 @@ namespace WebApplication.Controllers
             }
 
 
-        RetVal:
+            RetVal:
             if (taskTypeMappings.Count == 0)
             {
                 return NotFound();

--- a/solution/WebApplication/WebApplication/Services/AdsGoFastDapperContext.cs
+++ b/solution/WebApplication/WebApplication/Services/AdsGoFastDapperContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Policy;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;
@@ -17,23 +18,39 @@ namespace WebApplication.Services
     {
         private readonly AzureAuthenticationCredentialProvider _authProvider;
         private readonly string _connectionstring;
+        private readonly bool _isUsingFullConnectionString;
 
         public AdsGoFastDapperContext(AzureAuthenticationCredentialProvider authProvider, IOptions<ApplicationOptions> options)
         {
-            var scsb = new SqlConnectionStringBuilder
+            if (!string.IsNullOrEmpty(options.Value.ConnectionString))
             {
-                DataSource = options.Value.AdsGoFastTaskMetaDataDatabaseServer,
-                InitialCatalog = options.Value.AdsGoFastTaskMetaDataDatabaseName
-            };
-            _connectionstring = scsb.ConnectionString;
+                _connectionstring = options.Value.ConnectionString;
+                _isUsingFullConnectionString = true;
+            }
+            else
+            {
+                var scsb = new SqlConnectionStringBuilder
+                {
+                    DataSource = options.Value.AdsGoFastTaskMetaDataDatabaseServer,
+                    InitialCatalog = options.Value.AdsGoFastTaskMetaDataDatabaseName
+                };
+                _connectionstring = scsb.ConnectionString;
+            }
+
             _authProvider = authProvider;
         }
 
         public async Task<SqlConnection> GetConnection()
         {
             SqlConnection _con = new SqlConnection(_connectionstring);
-            string _token = await _authProvider.GetMsalRestApiToken(new Azure.Core.TokenRequestContext(new string[] { "https://database.windows.net//.default" }), new System.Threading.CancellationToken());
-            _con.AccessToken = _token;
+            if (!_isUsingFullConnectionString)
+            {
+                string _token = await _authProvider.GetMsalRestApiToken(
+                    new Azure.Core.TokenRequestContext(new string[] { "https://database.windows.net//.default" }),
+                    new System.Threading.CancellationToken());
+                _con.AccessToken = _token;
+            }
+
             return _con;
         }
     }

--- a/solution/WebApplication/WebApplication/Views/IntegrationRuntime/Create.cshtml
+++ b/solution/WebApplication/WebApplication/Views/IntegrationRuntime/Create.cshtml
@@ -1,0 +1,38 @@
+@using Humanizer;
+@model WebApplication.Models.IntegrationRuntime
+
+@{
+    ViewData["Title"] = "Create - " + "TaskGroup".Humanize(LetterCasing.Title);
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<h1>Create</h1>
+
+<h4> @("TaskGroup".Humanize(LetterCasing.Title))</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="IntegrationRuntimeName" class="control-label"></label>
+                <input asp-for="IntegrationRuntimeName" class="form-control" />
+                <span asp-validation-for="IntegrationRuntimeName" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="DataFactoryId" class="control-label"></label>
+                <select asp-for="DataFactoryId" class="form-control" asp-items="ViewBag.DataFactories"></select>
+            </div>
+            <div class="form-group form-check">
+                <label class="form-check-label">
+                    <input class="form-check-input" asp-for="ActiveYn" /> @Html.DisplayNameFor(model => model.ActiveYn)
+                </label>
+            </div>
+
+            <div class="form-group">
+                <a href="javascript:history.go(-1)" title="Back to List" class="btn btn-secondary"><i class="fa fa-arrow-circle-left"></i> Back</a>
+                <input type="submit" value="Create" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>

--- a/solution/WebApplication/WebApplication/Views/IntegrationRuntime/Delete.cshtml
+++ b/solution/WebApplication/WebApplication/Views/IntegrationRuntime/Delete.cshtml
@@ -1,0 +1,41 @@
+@using Humanizer; 
+@model WebApplication.Models.IntegrationRuntime
+
+@{
+        ViewData["Title"] = "Delete - " + "TaskGroup".Humanize(LetterCasing.Title);
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<h1>Delete</h1>
+
+<h3>Are you sure you want to delete this !!!!!?</h3>
+<div>
+    <h4> @("TaskGroup".Humanize(LetterCasing.Title))</h4>
+    <hr />
+    <dl class="row">
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.IntegrationRuntimeName)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.IntegrationRuntimeName)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.DataFactoryId)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.DataFactoryId)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.ActiveYn)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.ActiveYn)
+        </dd>
+    </dl>
+    
+    <form asp-action="Delete">
+        <input type="hidden" asp-for="IntegrationRuntimeId" />
+        <a href="javascript:history.go(-1)" title="Back to List" class="btn btn-secondary" ><i class="fa fa-arrow-circle-left"></i> Back</a>
+        <input type="submit" value="Delete" class="btn btn-danger"/>  
+    </form>
+</div>

--- a/solution/WebApplication/WebApplication/Views/IntegrationRuntime/Details.cshtml
+++ b/solution/WebApplication/WebApplication/Views/IntegrationRuntime/Details.cshtml
@@ -1,0 +1,44 @@
+@using Humanizer;
+@model WebApplication.Models.IntegrationRuntime
+
+@{
+    ViewData["Title"] = "Details - " + "IntegrationRuntime".Humanize(LetterCasing.Title);
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<h1>Details</h1>
+
+<div>
+    <h4> @("IntegrationRuntime".Humanize(LetterCasing.Title))</h4>
+    <hr />
+    <dl class="row">
+            <dt class = "col-sm-2">
+                @Html.DisplayNameFor(model => model.DataFactory.Name)
+            </dt>
+            <dd class = "col-sm-10">
+                @Html.DisplayFor(model => model.DataFactory.Name)
+            </dd>
+                <dt class = "col-sm-2">
+                    @Html.DisplayNameFor(model => model.IntegrationRuntimeId)
+                </dt>
+                <dd class = "col-sm-10">
+                    @Html.DisplayFor(model => model.IntegrationRuntimeId)
+                </dd>               
+                <dt class = "col-sm-2">
+                    @Html.DisplayNameFor(model => model.IntegrationRuntimeName)
+                </dt>
+                <dd class = "col-sm-10">
+                    @Html.DisplayFor(model => model.IntegrationRuntimeName)
+                </dd>
+        <dt class = "col-sm-2">
+                    @Html.DisplayNameFor(model => model.ActiveYn)
+                </dt>
+                <dd class = "col-sm-10">
+                    @Html.DisplayFor(model => model.ActiveYn)
+                </dd>               
+    </dl>
+</div>
+<div>
+    <a href="javascript:history.go(-1)" title="Back to List" class="btn btn-secondary"><i class="fa fa-arrow-circle-left"></i> Back</a>
+    <a asp-action="Edit" asp-route-id="@Model.IntegrationRuntimeId" class="btn btn-warning details" title="Edit"><i class="fa fa-pencil-square-o"></i> Edit</a> 
+</div>

--- a/solution/WebApplication/WebApplication/Views/IntegrationRuntime/Edit.cshtml
+++ b/solution/WebApplication/WebApplication/Views/IntegrationRuntime/Edit.cshtml
@@ -1,0 +1,41 @@
+@using Humanizer; 
+@model WebApplication.Models.IntegrationRuntime
+
+@{
+    ViewData["Title"] = "Edit - " + "TaskGroup".Humanize(LetterCasing.Title);
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<h1>Edit</h1>
+
+<h4> @("TaskGroup".Humanize(LetterCasing.Title))</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" name="returnUrl" value="@ViewBag.returnUrl" />
+            <div class="form-group">
+                <label asp-for="IntegrationRuntimeName" class="control-label"></label>
+                <input asp-for="IntegrationRuntimeName" class="form-control" />
+                <span asp-validation-for="IntegrationRuntimeName" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="DataFactoryId" class="control-label"></label>
+                <select asp-for="DataFactoryId" class="form-control" asp-items="ViewBag.DataFactories"></select>
+            </div>
+            <div class="form-group form-check">
+                <label class="form-check-label">
+                    <input class="form-check-input" asp-for="ActiveYn" /> @Html.DisplayNameFor(model => model.ActiveYn)
+                </label>
+            </div>
+            
+            <div class="form-group">
+                <a href="javascript:history.go(-1)" title="Back to List" class="btn btn-secondary" ><i class="fa fa-arrow-circle-left"></i> Back</a>            
+                <input type="submit" value="Save" class="btn btn-danger" />
+            </div>
+        </form>
+    </div>
+</div>
+
+

--- a/solution/WebApplication/WebApplication/Views/IntegrationRuntime/Index.cshtml
+++ b/solution/WebApplication/WebApplication/Views/IntegrationRuntime/Index.cshtml
@@ -1,0 +1,27 @@
+@model IEnumerable<WebApplication.Models.IntegrationRuntime>
+
+@{
+    ViewData["Title"] = "Index";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+
+<h1>Task Group - Browse</h1>
+<table id="adsgofast_tablelist" class="table table-striped">
+    <thead class="thead">
+        <tr>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>
+
+@section Scripts
+{
+    <script type="text/javascript">
+        var ModelName = "IntegrationRuntime";
+        $(document).ready(function () {
+            DataTablesGridPrep();
+        });
+    </script>
+}  

--- a/solution/WebApplication/WebApplication/Views/IntegrationRuntime/IndexDataTable.cshtml
+++ b/solution/WebApplication/WebApplication/Views/IntegrationRuntime/IndexDataTable.cshtml
@@ -1,0 +1,28 @@
+@using Humanizer;
+@model IEnumerable<WebApplication.Models.IntegrationRuntime>
+
+@{
+    ViewData["Title"] = typeof(IntegrationRuntime).Name.Pluralize().Humanize(LetterCasing.Title);
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+
+<h1><i id="PageIcon" class="fas fa-object-group"></i> @typeof(IntegrationRuntime).Name.Pluralize().Humanize(LetterCasing.Title)</h1>
+<table id="adsgofast_tablelist" class="table table-striped">
+    <thead class="thead">
+        <tr>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>
+
+@section Scripts
+{
+    <script type="text/javascript">
+        var ModelName = "IntegrationRuntime";
+        $(document).ready(function () {
+            DataTablesGridPrep();
+        });
+    </script>
+}  

--- a/solution/WebApplication/WebApplication/Views/Shared/_Layout.cshtml
+++ b/solution/WebApplication/WebApplication/Views/Shared/_Layout.cshtml
@@ -53,6 +53,7 @@
                         <li>
                             <a class="dropdown-item" asp-area="" asp-controller="SourceAndTargetSystemsJsonSchema" asp-action="IndexDataTable"><i class="fab fa-js" style="width:16px" title=""></i> Source / Target System JSON Schema</a>
                             <a class="dropdown-item" asp-area="" asp-controller="DataFactory" asp-action="IndexDataTable"><i class="fas fa-industry" style="width:16px" title=""></i> Data Factories</a>
+                            <a class="dropdown-item" asp-area="" asp-controller="IntegrationRuntime" asp-action="IndexDataTable"><i class="fas fa-rocket" style="width:16px" title=""></i> Integration Runtimes</a>
                         </li>
                     </ul>
                 </li>
@@ -127,7 +128,7 @@
                         </li>
                     </ul>
                 </li>
-                <li>
+                @*<li>
                     <a href="#pageSubmenuConfigWiz" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">Configuration Wizards</a>
                     <ul class="collapse list-unstyled" id="pageSubmenuConfigWiz">
                         <li>
@@ -136,7 +137,7 @@
                             </a>
                         </li>
                     </ul>
-                </li>
+                </li>*@
                 <li>
                     <a href="#pageSubmenuReports" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">Reports</a>
                     <ul class="collapse list-unstyled" id="pageSubmenuReports">

--- a/solution/WebApplication/WebApplication/Views/TaskMaster/Create.cshtml
+++ b/solution/WebApplication/WebApplication/Views/TaskMaster/Create.cshtml
@@ -15,6 +15,7 @@
         <form asp-action="Create">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
+                <input type="hidden" name="returnUrl" value="@ViewBag.returnUrl" />
                 <label asp-for="TaskMasterName" class="control-label"></label>
                 <input asp-for="TaskMasterName" class="form-control" />
                 <span asp-validation-for="TaskMasterName" class="text-danger"></span>

--- a/solution/WebApplication/WebApplication/Views/TaskMaster/Edit.cshtml
+++ b/solution/WebApplication/WebApplication/Views/TaskMaster/Edit.cshtml
@@ -16,6 +16,7 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="TaskMasterId" />
             <div class="form-group">
+                <input type="hidden" name="returnUrl" value="@ViewBag.returnUrl" />
                 <label asp-for="TaskMasterName" class="control-label"></label>
                 <input asp-for="TaskMasterName" class="form-control" />
                 <span asp-validation-for="TaskMasterName" class="text-danger"></span>

--- a/solution/WebApplication/WebApplication/Views/TaskMaster/EditPlus.cshtml
+++ b/solution/WebApplication/WebApplication/Views/TaskMaster/EditPlus.cshtml
@@ -114,12 +114,12 @@
                                 <label class="control-label">Target Sub-Type</label>
                                 <select id="TaskMasterJsonTargetType"></select>
                             </div>
-                            <div class="col">
+                            @*<div class="col">
                                 <label class="control-label">Data Factory IR</label>
                                 <select id="TaskDatafactoryIrSelect"></select>
                                 <span asp-validation-for="TaskDatafactoryIr" class="text-danger"></span>
                                 @Html.HiddenFor(x => x.TaskDatafactoryIr)
-                            </div>
+                            </div>*@
                         </div>
                     </div>
                     <br />
@@ -144,6 +144,7 @@
                 <div class="row">
                     <div class="mx-auto">
                         <div class="form-group">
+                            <input type="hidden" name="returnUrl" value="@ViewBag.returnUrl" />
                             <label asp-for="DegreeOfCopyParallelism" class="control-label"></label>
                             <input asp-for="DegreeOfCopyParallelism" class="form-control" />
                             <span asp-validation-for="DegreeOfCopyParallelism" class="text-danger"></span>
@@ -153,9 +154,9 @@
                                 <input class="form-check-input" asp-for="AllowMultipleActiveInstances" /> @Html.DisplayNameFor(model => model.AllowMultipleActiveInstances)
                             </label>
                         </div>
-                        <div class="form-group" style="display:none">
+                        <div class="form-group">
                             <label asp-for="TaskDatafactoryIr" class="control-label"></label>
-                            <select asp-for="TaskDatafactoryIr" class="form-control" asp-items="ViewBag.TaskDatafactoryIr"></select>
+                            <select asp-for="TaskDatafactoryIr" class="form-control" asp-items="ViewBag.IntegrationRuntimes"></select>
                             <span asp-validation-for="TaskDatafactoryIr" class="text-danger"></span>
                         </div>
 

--- a/solution/WebApplication/WebApplication/Views/TaskTypeMapping/Create.cshtml
+++ b/solution/WebApplication/WebApplication/Views/TaskTypeMapping/Create.cshtml
@@ -50,11 +50,6 @@
                 <span asp-validation-for="TargetType" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="TaskDatafactoryIr" class="control-label"></label>
-                <input asp-for="TaskDatafactoryIr" class="form-control" />
-                <span asp-validation-for="TaskDatafactoryIr" class="text-danger"></span>
-            </div>
-            <div class="form-group">
                 <label asp-for="TaskTypeJson" class="control-label"></label>
                 <input asp-for="TaskTypeJson" class="form-control" />
                 <span asp-validation-for="TaskTypeJson" class="text-danger"></span>

--- a/solution/WebApplication/WebApplication/Views/TaskTypeMapping/Delete.cshtml
+++ b/solution/WebApplication/WebApplication/Views/TaskTypeMapping/Delete.cshtml
@@ -57,12 +57,6 @@
             @Html.DisplayFor(model => model.TargetType)
         </dd>
         <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.TaskDatafactoryIr)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.TaskDatafactoryIr)
-        </dd>
-        <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.TaskTypeJson)
         </dt>
         <dd class = "col-sm-10">

--- a/solution/WebApplication/WebApplication/Views/TaskTypeMapping/Details.cshtml
+++ b/solution/WebApplication/WebApplication/Views/TaskTypeMapping/Details.cshtml
@@ -19,61 +19,55 @@
             <dd class = "col-sm-10">
                 @Html.DisplayFor(model => model.TaskType.TaskTypeName)
             </dd>
-                <dt class = "col-sm-2">
-                    @Html.DisplayNameFor(model => model.MappingType)
-                </dt>
-                <dd class = "col-sm-10">
-                    @Html.DisplayFor(model => model.MappingType)
-                </dd>               
-                <dt class = "col-sm-2">
-                    @Html.DisplayNameFor(model => model.MappingName)
-                </dt>
-                <dd class = "col-sm-10">
-                    @Html.DisplayFor(model => model.MappingName)
-                </dd>               
-                <dt class = "col-sm-2">
-                    @Html.DisplayNameFor(model => model.SourceSystemType)
-                </dt>
-                <dd class = "col-sm-10">
-                    @Html.DisplayFor(model => model.SourceSystemType)
-                </dd>               
-                <dt class = "col-sm-2">
-                    @Html.DisplayNameFor(model => model.SourceType)
-                </dt>
-                <dd class = "col-sm-10">
-                    @Html.DisplayFor(model => model.SourceType)
-                </dd>               
-                <dt class = "col-sm-2">
-                    @Html.DisplayNameFor(model => model.TargetSystemType)
-                </dt>
-                <dd class = "col-sm-10">
-                    @Html.DisplayFor(model => model.TargetSystemType)
-                </dd>               
-                <dt class = "col-sm-2">
-                    @Html.DisplayNameFor(model => model.TargetType)
-                </dt>
-                <dd class = "col-sm-10">
-                    @Html.DisplayFor(model => model.TargetType)
-                </dd>               
-                <dt class = "col-sm-2">
-                    @Html.DisplayNameFor(model => model.TaskDatafactoryIr)
-                </dt>
-                <dd class = "col-sm-10">
-                    @Html.DisplayFor(model => model.TaskDatafactoryIr)
-                </dd>               
-             <dt class = "col-sm-2">
+            <dt class = "col-sm-2">
+                @Html.DisplayNameFor(model => model.MappingType)
+            </dt>
+            <dd class = "col-sm-10">
+                @Html.DisplayFor(model => model.MappingType)
+            </dd>               
+            <dt class = "col-sm-2">
+                @Html.DisplayNameFor(model => model.MappingName)
+            </dt>
+            <dd class = "col-sm-10">
+                @Html.DisplayFor(model => model.MappingName)
+            </dd>               
+            <dt class = "col-sm-2">
+                @Html.DisplayNameFor(model => model.SourceSystemType)
+            </dt>
+            <dd class = "col-sm-10">
+                @Html.DisplayFor(model => model.SourceSystemType)
+            </dd>               
+            <dt class = "col-sm-2">
+                @Html.DisplayNameFor(model => model.SourceType)
+            </dt>
+            <dd class = "col-sm-10">
+                @Html.DisplayFor(model => model.SourceType)
+            </dd>               
+            <dt class = "col-sm-2">
+                @Html.DisplayNameFor(model => model.TargetSystemType)
+            </dt>
+            <dd class = "col-sm-10">
+                @Html.DisplayFor(model => model.TargetSystemType)
+            </dd>               
+            <dt class = "col-sm-2">
+                @Html.DisplayNameFor(model => model.TargetType)
+            </dt>
+            <dd class = "col-sm-10">
+                @Html.DisplayFor(model => model.TargetType)
+            </dd>
+            <dt class = "col-sm-2">
                 @Html.DisplayNameFor(model => model.TaskTypeJson)
             </dt>
             <dd class = "col-sm-10 jsonpretty">
                 <a class="jsonraw">@Html.DisplayFor(model => model.TaskTypeJson)</a>
                 <div class="jsonformatted"></div>
             </dd>
-                <dt class = "col-sm-2">
-                    @Html.DisplayNameFor(model => model.ActiveYn)
-                </dt>
-                <dd class = "col-sm-10">
-                    @Html.DisplayFor(model => model.ActiveYn)
-                </dd>               
+            <dt class = "col-sm-2">
+                @Html.DisplayNameFor(model => model.ActiveYn)
+            </dt>
+            <dd class = "col-sm-10">
+                @Html.DisplayFor(model => model.ActiveYn)
+            </dd>               
              <dt class = "col-sm-2">
                 @Html.DisplayNameFor(model => model.TaskMasterJsonSchema)
             </dt>

--- a/solution/WebApplication/WebApplication/Views/TaskTypeMapping/Edit.cshtml
+++ b/solution/WebApplication/WebApplication/Views/TaskTypeMapping/Edit.cshtml
@@ -52,11 +52,6 @@
                 <span asp-validation-for="TargetType" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="TaskDatafactoryIr" class="control-label"></label>
-                <input asp-for="TaskDatafactoryIr" class="form-control" />
-                <span asp-validation-for="TaskDatafactoryIr" class="text-danger"></span>
-            </div>
-            <div class="form-group">
                 <label asp-for="TaskTypeJson" class="control-label"></label>
                 <input asp-for="TaskTypeJson" class="form-control" />
                 <span asp-validation-for="TaskTypeJson" class="text-danger"></span>

--- a/solution/WebApplication/WebApplication/Views/TaskTypeMapping/Index.cshtml
+++ b/solution/WebApplication/WebApplication/Views/TaskTypeMapping/Index.cshtml
@@ -39,9 +39,6 @@
                 @Html.DisplayNameFor(model => model.TargetType)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.TaskDatafactoryIr)
-            </th>
-            <th>
                 @Html.DisplayNameFor(model => model.TaskTypeJson)
             </th>
             <th>
@@ -86,9 +83,6 @@
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.TargetType)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.TaskDatafactoryIr)
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.TaskTypeJson)

--- a/solution/WebApplication/WebApplication/WebApplication.csproj
+++ b/solution/WebApplication/WebApplication/WebApplication.csproj
@@ -71,4 +71,15 @@
     <ProjectReference Include="..\WebApplication.DataAccess\WebApplication.DataAccess.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="Views\IntegrationRuntime\Create.cshtml">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="Views\IntegrationRuntime\Delete.cshtml">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/solution/WebApplication/WebApplication/wwwroot/js/TaskMasterEditPlus.js
+++ b/solution/WebApplication/WebApplication/wwwroot/js/TaskMasterEditPlus.js
@@ -57,15 +57,6 @@ $("#TaskMasterJsonTargetType").change(function () {
     EnterStep4a();
 });
 
-$("#TaskDatafactoryIrSelect").change(function () {
-    EnterStep4a();
-});
-
-$("#TaskDatafactoryIrSelect").change(function () {
-    EnterStep4a();
-});
-
-
 const merge = (...arguments) => {
 
     // create a new object
@@ -272,32 +263,33 @@ function EnterStep4c() {
     GetTaskMasterJson_Target();
 
 
-    var validDatafactoryIrs = [];
-    $.each(taskTypeMappings.TaskTypeMappings, function (key, value) {
-        if (value.SourceSystemType === SourceSystemType && value.TargetSystemType === TargetSystemType && value.SourceType === SourceSubType && value.TargetType === TargetSubType) {
-            if (!validDatafactoryIrs.includes(value.TaskDatafactoryIr)) {
-                validDatafactoryIrs.push(value.TaskDatafactoryIr);
-            }
-        }
-    })
+    //var validDatafactoryIrs = [];
+    //$.each(taskTypeMappings.TaskTypeMappings, function (key, value) {
+    //    if (value.SourceSystemType === SourceSystemType && value.TargetSystemType === TargetSystemType && value.SourceType === SourceSubType && value.TargetType === TargetSubType) {
+    //        if (!validDatafactoryIrs.includes(value.TaskDatafactoryIr)) {
+    //            validDatafactoryIrs.push(value.TaskDatafactoryIr);
+    //        }
+    //    }
+    //})
 
-    //Populate Valid Target Sub Types
-    var currentDataFactoryIr = GetCurrentlySelectedDatafactoryIr();
-    $('#TaskDatafactoryIrSelect option').remove();
-    if (!currentDataFactoryIr)
-        $('#TaskDatafactoryIrSelect').append($('<option value=""></option>'));
+    ////Populate Valid Target Sub Types
+    //var currentDataFactoryIr = GetCurrentlySelectedDatafactoryIr();
+    //$('#TaskDatafactoryIrSelect option').remove();
+    //if (!currentDataFactoryIr)
+    //    $('#TaskDatafactoryIrSelect').append($('<option value=""></option>'));
 
-    $.each(validDatafactoryIrs, function (key, value) {
-        var opt = $('<option value="' + value + '">' + value + '</option>')
-        if (opt.val() == currentDataFactoryIr) {
-            opt.attr('selected', 'selected');
-        }
-        $('#TaskDatafactoryIrSelect').append(opt);
-    })
+    //$.each(validDatafactoryIrs, function (key, value) {
+    //    var opt = $('<option value="' + value + '">' + value + '</option>')
+    //    if (opt.val() == currentDataFactoryIr) {
+    //        opt.attr('selected', 'selected');
+    //    }
+    //    $('#TaskDatafactoryIrSelect').append(opt);
+    //})
 
-    if ($(':selected', $('#TaskDatafactoryIrSelect')).val()) {
-        CreateJsonEditor();
-    }
+    //if ($(':selected', $('#TaskDatafactoryIrSelect')).val()) {
+    //    CreateJsonEditor();
+    //}
+    CreateJsonEditor();
 }
 
 function EnterStep5() {
@@ -313,14 +305,14 @@ function CreateJsonEditor() {
     var SourceSystemType = GetCurrentlySelectedSourceSystem().SystemType;
     var TargetSubType = GetCurrentlySelectedTargetSubType();
     var SourceSubType = GetCurrentlySelectedSourceSubType();
-    var DatafactoryIr = GetCurrentlySelectedDatafactoryIr();
+    /*var DatafactoryIr = GetCurrentlySelectedDatafactoryIr();*/
 
     //Update DatafactoryIr in Form Input
-    $('#TaskDatafactoryIr').val(DatafactoryIr);
+    //$('#TaskDatafactoryIr').val(DatafactoryIr);
 
     var SelectedTaskTypeMapping;
     $.each(taskTypeMappings.TaskTypeMappings, function (key, value) {
-        if (value.SourceSystemType === SourceSystemType && value.TargetSystemType === TargetSystemType && value.TargetType === TargetSubType && value.SourceType === SourceSubType && value.TaskDatafactoryIr === DatafactoryIr) {
+        if (value.SourceSystemType === SourceSystemType && value.TargetSystemType === TargetSystemType && value.TargetType === TargetSubType && value.SourceType === SourceSubType) {
             SelectedTaskTypeMapping = value;
         }
     })
@@ -397,12 +389,12 @@ function GetCurrentlySelectedTargetSystem() {
     return Selected;
 }
 
-function GetCurrentlySelectedDatafactoryIr() {
-    var selected = $(':selected', $('#TaskDatafactoryIrSelect')).val();
-    if (!selected)
-        selected = $('#TaskDatafactoryIr').val();
-    return selected;
-}
+//function GetCurrentlySelectedDatafactoryIr() {
+//    var selected = $(':selected', $('#TaskDatafactoryIrSelect')).val();
+//    if (!selected)
+//        selected = $('#TaskDatafactoryIr').val();
+//    return selected;
+//}
 
 function GetCurrentlySelectedTargetSubType() {
     if (JSON.parse($('#TaskMasterJson').val()) === undefined) {


### PR DESCRIPTION
*   Removed IR from the TaskTypeMapping table so that we only need to maintain a single TaskTypeMapping & schema per task type (not per TaskType & IntegrationRuntime)
*   Added IntegrationRuntime controller, model, dbcontext & views
*   Added ConnectionString support to Dapper so that you can run the app against local DBs easily
*   Fixed missing returnUrl on TaskMaster page causing errors.
*   Updated TaskMaster EditPlus to no longer use IR info from the TaskTypeMapping table
    *   This has caused a slight regression that means there is less Source/Target system filtering. This will be addressed in a future commit.