### PR TITLE
Replaced hardcoded 1900-01-01 date within schedule instance SQL query

### DIFF
--- a/solution/FunctionApp/FunctionApp/Functions/AdfPrepareFrameworkTasksTimerTrigger.cs
+++ b/solution/FunctionApp/FunctionApp/Functions/AdfPrepareFrameworkTasksTimerTrigger.cs
@@ -115,7 +115,7 @@ namespace FunctionApp.Functions
                 Select 
 	                SM.ScheduleMasterId, 
 	                SM.ScheduleCronExpression, 
-	                Coalesce(SI.MaxScheduledDateTimeOffset,cast('1900-01-01' as datetimeoffset)) as MaxScheduledDateTimeOffset
+	                Coalesce(SI.MaxScheduledDateTimeOffset,dateadd(minute, -1, sysdatetimeoffset())) as MaxScheduledDateTimeOffset
                 from
                     ScheduleMaster SM 
 	                join ( 


### PR DESCRIPTION
Fix for intraday e.g. every hour, every 15min, etc. scheduling. Previously causing task instances to run every 2 minutes regardless of task master linked schedule