### PR TITLE
Fixes to enable deployment of Databricks in feature 2.0.2

### DIFF
--- a/solution/DeploymentV2/terraform_layer0/nsg_databricks.tf
+++ b/solution/DeploymentV2/terraform_layer0/nsg_databricks.tf
@@ -9,10 +9,24 @@ resource "azurerm_subnet_network_security_group_association" "db_container" {
   count                     = (var.is_vnet_isolated ? 1 : 0)
   subnet_id                 = local.databricks_container_subnet_id
   network_security_group_id = azurerm_network_security_group.databricks_nsg[0].id
+
+  # The subnet will refuse to accept the NSG if it's not this exact
+  # list so we need to ensure the rules are deployed before the association
+  depends_on = [
+    azurerm_subnet.databricks_container_subnet[0],
+  ]
+  timeouts {}
 }
 
 resource "azurerm_subnet_network_security_group_association" "db_host" {
-  count                     = (var.is_vnet_isolated ? 1 : 0)    
+  count                     = (var.is_vnet_isolated ? 1 : 0)
   subnet_id                 = local.databricks_host_subnet_id
   network_security_group_id = azurerm_network_security_group.databricks_nsg[0].id
+
+  # The subnet will refuse to accept the NSG if it's not this exact
+  # list so we need to ensure the rules are deployed before the association
+  depends_on = [
+    azurerm_subnet.databricks_host_subnet[0],
+  ]
+  timeouts {}
 }

--- a/solution/DeploymentV2/terraform_layer2/databricks.tf
+++ b/solution/DeploymentV2/terraform_layer2/databricks.tf
@@ -80,6 +80,7 @@ resource "azurerm_role_assignment" "databricks_data_factory" {
 } 
 */
 
+/*
 resource "databricks_workspace_conf" "this" {
   count    = var.deploy_databricks ? 1 : 0
   provider = databricks.created_workspace
@@ -88,7 +89,9 @@ resource "databricks_workspace_conf" "this" {
   }
   depends_on = [databricks_ip_access_list.allowed-list]
 }
+*/
 
+/*
 resource "databricks_ip_access_list" "allowed-list" {
   count     = var.deploy_databricks ? 1 : 0
   provider = databricks.created_workspace
@@ -99,6 +102,7 @@ resource "databricks_ip_access_list" "allowed-list" {
     var.ip_address2
   ]
 }
+*/
 
 
 
@@ -106,6 +110,7 @@ provider "databricks" {
   host = var.deploy_databricks ? azurerm_databricks_workspace.workspace[0].workspace_url : ""
 }
 
+/*
 resource "databricks_instance_pool" "smallest_nodes" {
   count              = var.deploy_databricks ? 1 : 0
   instance_pool_name = "Job Pool One"
@@ -125,4 +130,4 @@ resource "databricks_instance_pool" "smallest_nodes" {
   }
   depends_on = [azurerm_databricks_workspace.workspace]
 }
-
+*/


### PR DESCRIPTION
Add "depends_on" targeting subnets for NSG associations
comment out Databricks IP access-list and Instance pool due to reliance on the Databricks API PAT token (not yet implemented)